### PR TITLE
Parse a state action string like a shell

### DIFF
--- a/tfmigrate/multi_state_action.go
+++ b/tfmigrate/multi_state_action.go
@@ -3,7 +3,6 @@ package tfmigrate
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/minamijoyo/tfmigrate/tfexec"
 )
@@ -22,8 +21,11 @@ type MultiStateAction interface {
 // Valid formats are the following.
 // "mv <source> <destination>"
 func NewMultiStateActionFromString(cmdStr string) (MultiStateAction, error) {
-	// split cmdStr using Fields instead of Split to allow cmdStr to have duplicated white spaces.
-	args := strings.Fields(cmdStr)
+	args, err := splitStateAction(cmdStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse action: %s, err: %s", cmdStr, err)
+	}
+
 	if len(args) == 0 {
 		return nil, fmt.Errorf("multi state action is empty: %s", cmdStr)
 	}

--- a/tfmigrate/state_action.go
+++ b/tfmigrate/state_action.go
@@ -3,8 +3,8 @@ package tfmigrate
 import (
 	"context"
 	"fmt"
-	"strings"
 
+	"github.com/mattn/go-shellwords"
 	"github.com/minamijoyo/tfmigrate/tfexec"
 )
 
@@ -23,8 +23,11 @@ type StateAction interface {
 // "rm <addresses>...
 // "import <address> <id>"
 func NewStateActionFromString(cmdStr string) (StateAction, error) {
-	// split cmdStr using Fields instead of Split to allow cmdStr to have duplicated white spaces.
-	args := strings.Fields(cmdStr)
+	args, err := splitStateAction(cmdStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse action: %s, err: %s", cmdStr, err)
+	}
+
 	if len(args) == 0 {
 		return nil, fmt.Errorf("state action is empty: %s", cmdStr)
 	}
@@ -61,4 +64,10 @@ func NewStateActionFromString(cmdStr string) (StateAction, error) {
 	}
 
 	return action, nil
+}
+
+// splitStateAction splits a given string like a shell.
+func splitStateAction(cmdStr string) ([]string, error) {
+	// Note that we cannot simply split it by space because the address of resource can contain spaces.
+	return shellwords.Parse(cmdStr)
 }

--- a/tfmigrate/state_action_test.go
+++ b/tfmigrate/state_action_test.go
@@ -98,6 +98,15 @@ func TestNewStateActionFromString(t *testing.T) {
 			ok: true,
 		},
 		{
+			desc:   "a white space in resource address",
+			cmdStr: `mv docker_container.nginx 'docker_container.nginx["This is an example"]'`,
+			want: &StateMvAction{
+				source:      "docker_container.nginx",
+				destination: `docker_container.nginx["This is an example"]`,
+			},
+			ok: true,
+		},
+		{
 			desc:   "unknown type",
 			cmdStr: "foo bar baz",
 			want:   nil,
@@ -108,6 +117,55 @@ func TestNewStateActionFromString(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 			got, err := NewStateActionFromString(tc.cmdStr)
+			if tc.ok && err != nil {
+				t.Fatalf("unexpected err: %s", err)
+			}
+			if !tc.ok && err == nil {
+				t.Fatalf("expected to return an error, but no error, got: %#v", got)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got: %#v, want: %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSplitStateAction(t *testing.T) {
+	cases := []struct {
+		desc   string
+		cmdStr string
+		want   []string
+		ok     bool
+	}{
+		{
+			desc:   "simple",
+			cmdStr: "mv aws_security_group.foo aws_security_group.foo2",
+			want:   []string{"mv", "aws_security_group.foo", "aws_security_group.foo2"},
+			ok:     true,
+		},
+		{
+			desc:   "duplicated white spaces",
+			cmdStr: " mv  aws_security_group.foo    aws_security_group.foo2 ",
+			want:   []string{"mv", "aws_security_group.foo", "aws_security_group.foo2"},
+			ok:     true,
+		},
+		{
+			desc:   "a white space in resource address",
+			cmdStr: `mv docker_container.nginx 'docker_container.nginx["This is an example"]'`,
+			want:   []string{"mv", "docker_container.nginx", `docker_container.nginx["This is an example"]`},
+			ok:     true,
+		},
+		{
+			desc:   "syntax error (unmatch quote)",
+			cmdStr: `mv foo 'bar`,
+			want:   nil,
+			ok:     false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got, err := splitStateAction(tc.cmdStr)
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err: %s", err)
 			}


### PR DESCRIPTION
Fixes #5
We cannot simply split it by space because the address of resource can contain spaces.
We should parse it like a shell with go-shellwords.