### PR TITLE
Show diffs in log if force is set to true

### DIFF
--- a/tfmigrate/multi_state_migrator.go
+++ b/tfmigrate/multi_state_migrator.go
@@ -120,7 +120,7 @@ func (m *MultiStateMigrator) plan(ctx context.Context) (*tfexec.State, *tfexec.S
 	if err != nil {
 		if exitErr, ok := err.(tfexec.ExitError); ok && exitErr.ExitCode() == 2 {
 			if m.force {
-				log.Printf("[INFO] [migrator@%s] unexpected diffs, ignoring as force option is true", m.fromTf.Dir())
+				log.Printf("[INFO] [migrator@%s] unexpected diffs, ignoring as force option is true: %s", m.fromTf.Dir(), err)
 				return fromCurrentState, toCurrentState, nil
 			}
 			log.Printf("[ERROR] [migrator@%s] unexpected diffs\n", m.fromTf.Dir())

--- a/tfmigrate/state_migrator.go
+++ b/tfmigrate/state_migrator.go
@@ -113,7 +113,7 @@ func (m *StateMigrator) plan(ctx context.Context) (*tfexec.State, error) {
 	if err != nil {
 		if exitErr, ok := err.(tfexec.ExitError); ok && exitErr.ExitCode() == 2 {
 			if m.force {
-				log.Printf("[INFO] [migrator@%s] unexpected diffs, ignoring as force option is true", m.tf.Dir())
+				log.Printf("[INFO] [migrator@%s] unexpected diffs, ignoring as force option is true: %s", m.tf.Dir(), err)
 				return currentState, nil
 			}
 			log.Printf("[ERROR] [migrator@%s] unexpected diffs\n", m.tf.Dir())


### PR DESCRIPTION
After using force feature from #10 in my migrations I thought it would be nice to include plan diffs in log output so you can see what changes have been applied after applying migration with force true