### PR TITLE
Create a plugin cache directory in advance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,3 +11,5 @@ RUN go mod download
 
 COPY . .
 RUN make install
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# Create a plugin cache directory in advance.
+# The terraform command doesn't create it automatically.
+if [ -n "${TF_PLUGIN_CACHE_DIR}" ]; then
+  mkdir -p "${TF_PLUGIN_CACHE_DIR}"
+fi
+
+exec "$@"


### PR DESCRIPTION
I noticed that the following error occurs in docker-compose:

```
bash-5.0# terraform -v
There are some problems with the CLI configuration:

Error: The specified plugin cache dir /tmp/plugin-cache cannot be opened: stat /tmp/plugin-cache: no such file or directory


As a result of the above problems, Terraform may not behave as intended.


Terraform v0.14.3
```

The terraform command doesn't create it automatically. So create it in an entrypoint.sh in advance.