### PR TITLE
Add support for Terraform v0.15

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,9 +31,10 @@ jobs:
     strategy:
       matrix:
         terraform:
-        - 0.14.0
-        - 0.13.5
-        - 0.12.29
+        - 0.15.0
+        - 0.14.10
+        - 0.13.6
+        - 0.12.30
     env:
       TERRAFORM_VERSION: ${{ matrix.terraform }}
     steps:

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This brings us to a new paradigm, that is to say, Terraform state operation as C
 
 The tfmigrate invokes `terraform` command under the hood. This is because we want to support multiple terraform versions in a stable way. Currently supported terraform versions are as follows:
 
+- Terraform v0.15.x
 - Terraform v0.14.x
 - Terraform v0.13.x
 - Terraform v0.12.x


### PR DESCRIPTION
All we need is adding Terraform v0.15 to a test matrix.