### PR TITLE
Fix CI fail for TestExecutorDir in ubuntu-20.04

### DIFF
--- a/tfexec/executor_test.go
+++ b/tfexec/executor_test.go
@@ -169,8 +169,8 @@ func TestExecutorDir(t *testing.T) {
 		{
 			desc: "test set dir",
 			args: []string{"pwd"},
-			dir:  "/bin",
-			want: "/bin\n",
+			dir:  "/usr/local/bin",
+			want: "/usr/local/bin\n",
 			ok:   true,
 		},
 	}


### PR DESCRIPTION
The `ubuntu-latest` in GitHub Action has been changed from `ubuntu-18.04` to `ubuntu-20.04`, In `ubuntu-20.04`, `/bin` is a symlink to `/usr/bin`, this breaks the test for `TestExecutorDir`. It's ok changing it to any dir except not a symlink in all platforms on CI. So we change the test dir to `/usr/local/bin`.

```
$ docker run -it --rm ubuntu:18.04 ls -l /bin | head
total 4940
-rwxr-xr-x 1 root root 1113504 Jun  6  2019 bash
-rwxr-xr-x 3 root root   34888 Jul  4  2019 bunzip2
-rwxr-xr-x 3 root root   34888 Jul  4  2019 bzcat
lrwxrwxrwx 1 root root       6 Jul  4  2019 bzcmp -> bzdiff
-rwxr-xr-x 1 root root    2140 Jul  4  2019 bzdiff
lrwxrwxrwx 1 root root       6 Jul  4  2019 bzegrep -> bzgrep
-rwxr-xr-x 1 root root    4877 Jul  4  2019 bzexe
lrwxrwxrwx 1 root root       6 Jul  4  2019 bzfgrep -> bzgrep
-rwxr-xr-x 1 root root    3642 Jul  4  2019 bzgrep

$ docker run -it --rm ubuntu:20.04 ls -l /bin | head
lrwxrwxrwx 1 root root 7 Feb 17 01:04 /bin -> usr/bin
```

```
$ docker run -it --rm ubuntu:18.04 ls -l /usr/local/bin | head
total 0

$ docker run -it --rm ubuntu:20.04 ls -l /usr/local/bin | head
total 0
```