### PR TITLE
Support workspaces for multi-state migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,36 @@
 
 A Terraform state migration tool for GitOps.
 
+## Table of content
+<!--ts-->
+   * [Features](#features)
+   * [Why?](#why)
+   * [Supported Terraform versions](#supported-terraform-versions)
+   * [Getting Started](#getting-started)
+   * [Install](#install)
+      * [Homebrew](#homebrew)
+      * [Download](#download)
+      * [Source](#source)
+   * [Usage](#usage)
+   * [Configurations](#configurations)
+      * [Environment variables](#environment-variables)
+      * [Configuration file](#configuration-file)
+         * [tfmigrate block](#tfmigrate-block)
+         * [history block](#history-block)
+         * [storage block](#storage-block)
+         * [storage block (local)](#storage-block-local)
+         * [storage block (s3)](#storage-block-s3)
+   * [Migration file](#migration-file)
+      * [migration block](#migration-block)
+      * [migration block (state)](#migration-block-state)
+         * [state mv](#state-mv)
+         * [state rm](#state-rm)
+         * [state import](#state-import)
+      * [migration block (multi_state)](#migration-block-multi_state)
+         * [multi_state mv](#multi_state-mv)
+   * [License](#license)
+<!--te-->
+
 ## Features
 
 - GitOps friendly: Write terraform state mv/rm/import commands in HCL, plan and apply it.
@@ -454,7 +484,9 @@ migration "state" "test" {
 The `multi_state` migration updates states in two different directories. It is intended for moving resources across states. It has the following attributes.
 
 - `from_dir` (required): A working directory where states of resources move from.
+- `from_workspace` (optional): A terraform workspace in the FROM directory. Defaults to "default".
 - `to_dir` (required): A working directory where states of resources move to.
+- `to_workspace` (optional): A terraform workspace in the TO directory. Defaults to "default".
 - `actions` (required): Actions is a list of multi state action. An action is a plain text for state operation. Valid formats are the following.
   - `"mv <source> <destination>"`
 - `force` (optional): Apply migrations even if plan show changes

--- a/tfexec/terraform.go
+++ b/tfexec/terraform.go
@@ -225,8 +225,8 @@ terraform {
 	if err != nil {
 		// remove the override file before return an error.
 		os.Remove(path)
-		os.Remove(workspacePath)
 		os.Remove(workspaceStatePath)
+		os.Remove(workspacePath)
 		return nil, fmt.Errorf("failed to switch backend to local: %s", err)
 	}
 

--- a/tfexec/terraform.go
+++ b/tfexec/terraform.go
@@ -101,10 +101,16 @@ type TerraformCLI interface {
 	// StatePush pushs a given State to remote.
 	StatePush(ctx context.Context, state *State, opts ...string) error
 
-	// Switch to the workspace with name "workspace". This workspace should already exist
-	WorkspaceSelect(ctx context.Context, workspace string, dir string, opts ...string) error
+	// Create a new workspace with name "workspace".
+	WorkspaceNew(ctx context.Context, workspace string, dir string, opts ...string) error
 
-	// Run is a low-level generic method for running an arbitrary terraform comamnd.
+	// Returns the current selected workspace.
+	WorkspaceShow(ctx context.Context) (string, error)
+
+	// Switch to the workspace with name "workspace". This workspace should already exist
+	WorkspaceSelect(ctx context.Context, workspace string, dir string) error
+
+	// Run is a low-level generic method for running an arbitrary terraform command.
 	Run(ctx context.Context, args ...string) (string, string, error)
 
 	// dir returns a working directory where terraform command is executed.

--- a/tfexec/terraform_test.go
+++ b/tfexec/terraform_test.go
@@ -115,11 +115,6 @@ resource "aws_security_group" "bar" {}
 		t.Fatalf("expect to have changes")
 	}
 
-	// create local workspace folder
-	// this is a prerequisite before calling OverrideBackendToLocal
-	path := filepath.Join(terraformCLI.Dir(), "terraform.tfstate.d", workspace)
-	os.MkdirAll(path, os.ModePerm)
-
 	state, err := terraformCLI.StatePull(context.Background())
 	if err != nil {
 		t.Fatalf("failed to run terraform state pull: %s", err)

--- a/tfexec/terraform_test.go
+++ b/tfexec/terraform_test.go
@@ -124,8 +124,9 @@ resource "aws_security_group" "bar" {}
 	if _, err := os.Stat(filepath.Join(terraformCLI.Dir(), filename)); err == nil {
 		t.Fatalf("an override file already exists: %s", err)
 	}
+	workspace := "default"
 
-	switchBackToRemotekFunc, err := terraformCLI.OverrideBackendToLocal(context.Background(), filename)
+	switchBackToRemotekFunc, err := terraformCLI.OverrideBackendToLocal(context.Background(), filename, workspace)
 	if err != nil {
 		t.Fatalf("failed to run OverrideBackendToLocal: %s", err)
 	}

--- a/tfexec/terraform_workspace_new.go
+++ b/tfexec/terraform_workspace_new.go
@@ -1,0 +1,19 @@
+package tfexec
+
+import (
+	"context"
+)
+
+//WorkspaceNew creates a new workspace
+func (c *terraformCLI) WorkspaceNew(ctx context.Context, workspace string, dir string, opts ...string) error {
+	args := []string{"workspace", "new"}
+	args = append(args, opts...)
+	if len(workspace) > 0 {
+		args = append(args, workspace)
+	}
+	if len(dir) > 0 {
+		args = append(args, dir)
+	}
+	_, _, err := c.Run(ctx, args...)
+	return err
+}

--- a/tfexec/terraform_workspace_new.go
+++ b/tfexec/terraform_workspace_new.go
@@ -5,14 +5,11 @@ import (
 )
 
 //WorkspaceNew creates a new workspace
-func (c *terraformCLI) WorkspaceNew(ctx context.Context, workspace string, dir string, opts ...string) error {
+func (c *terraformCLI) WorkspaceNew(ctx context.Context, workspace string, opts ...string) error {
 	args := []string{"workspace", "new"}
 	args = append(args, opts...)
 	if len(workspace) > 0 {
 		args = append(args, workspace)
-	}
-	if len(dir) > 0 {
-		args = append(args, dir)
 	}
 	_, _, err := c.Run(ctx, args...)
 	return err

--- a/tfexec/terraform_workspace_new_test.go
+++ b/tfexec/terraform_workspace_new_test.go
@@ -10,12 +10,11 @@ func TestTerraformCLIWorkspaceNew(t *testing.T) {
 		desc         string
 		mockCommands []*mockCommand
 		workspace    string
-		dir          string
 		opts         []string
 		ok           bool
 	}{
 		{
-			desc: "no workspace, no dir, no opts",
+			desc: "no workspace, no opts",
 			mockCommands: []*mockCommand{
 				{
 					args:     []string{"terraform", "workspace", "new"},
@@ -36,27 +35,14 @@ func TestTerraformCLIWorkspaceNew(t *testing.T) {
 			ok:        true,
 		},
 		{
-			desc: "with workspace and dir",
+			desc: "with workspace and opts",
 			mockCommands: []*mockCommand{
 				{
-					args:     []string{"terraform", "workspace", "new", "foo", "bar"},
+					args:     []string{"terraform", "workspace", "new", "-lock=true", "-lock-timeout=0s", "foo"},
 					exitCode: 0,
 				},
 			},
 			workspace: "foo",
-			dir:       "bar",
-			ok:        true,
-		},
-		{
-			desc: "with workspace and dir and opts",
-			mockCommands: []*mockCommand{
-				{
-					args:     []string{"terraform", "workspace", "new", "-lock=true", "-lock-timeout=0s", "foo", "bar"},
-					exitCode: 0,
-				},
-			},
-			workspace: "foo",
-			dir:       "bar",
 			opts:      []string{"-lock=true", "-lock-timeout=0s"},
 			ok:        true,
 		},
@@ -65,7 +51,7 @@ func TestTerraformCLIWorkspaceNew(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			e := NewMockExecutor(tc.mockCommands)
 			terraformCLI := NewTerraformCLI(e)
-			err := terraformCLI.WorkspaceNew(context.Background(), tc.workspace, tc.dir, tc.opts...)
+			err := terraformCLI.WorkspaceNew(context.Background(), tc.workspace, tc.opts...)
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err: %s", err)
 			}
@@ -88,7 +74,7 @@ func TestAccTerraformCLIWorkspaceNew(t *testing.T) {
 		t.Fatalf("failed to run terraform init: %s", err)
 	}
 
-	err = terraformCLI.WorkspaceNew(context.Background(), "myworkspace", "")
+	err = terraformCLI.WorkspaceNew(context.Background(), "myworkspace")
 	if err != nil {
 		t.Fatalf("failed to create a new workspace: %s", err)
 	}
@@ -98,7 +84,7 @@ func TestAccTerraformCLIWorkspaceNew(t *testing.T) {
 		t.Fatalf("failed to run terraform workspace show: %s", err)
 	}
 
-	if got == "" {
+	if got != "myworkspace" {
 		t.Error("The current workspace doesn't match the workspace that was just created")
 	}
 }

--- a/tfexec/terraform_workspace_select.go
+++ b/tfexec/terraform_workspace_select.go
@@ -6,13 +6,10 @@ import (
 
 //WorkspaceSelect selects the workspace "workspace". The workspace needs to exist
 // in order for the switch to be successful
-func (c *terraformCLI) WorkspaceSelect(ctx context.Context, workspace string, dir string) error {
+func (c *terraformCLI) WorkspaceSelect(ctx context.Context, workspace string) error {
 	args := []string{"workspace", "select"}
 	if len(workspace) > 0 {
 		args = append(args, workspace)
-	}
-	if len(dir) > 0 {
-		args = append(args, dir)
 	}
 	_, _, err := c.Run(ctx, args...)
 	return err

--- a/tfexec/terraform_workspace_select.go
+++ b/tfexec/terraform_workspace_select.go
@@ -6,11 +6,14 @@ import (
 
 //WorkspaceSelect selects the workspace "workspace". The workspace needs to exist
 // in order for the switch to be successful
-func (c *terraformCLI) WorkspaceSelect(ctx context.Context, workspace string, opts ...string) error {
+func (c *terraformCLI) WorkspaceSelect(ctx context.Context, workspace string, dir string, opts ...string) error {
 	args := []string{"workspace", "select"}
 	args = append(args, opts...)
 	if len(workspace) > 0 {
 		args = append(args, workspace)
+	}
+	if len(dir) > 0 {
+		args = append(args, dir)
 	}
 	_, _, err := c.Run(ctx, args...)
 	return err

--- a/tfexec/terraform_workspace_select.go
+++ b/tfexec/terraform_workspace_select.go
@@ -1,0 +1,17 @@
+package tfexec
+
+import (
+	"context"
+)
+
+//WorkspaceSelect selects the workspace "workspace". The workspace needs to exist
+// in order for the switch to be successful
+func (c *terraformCLI) WorkspaceSelect(ctx context.Context, workspace string, opts ...string) error {
+	args := []string{"workspace", "select"}
+	args = append(args, opts...)
+	if len(workspace) > 0 {
+		args = append(args, workspace)
+	}
+	_, _, err := c.Run(ctx, args...)
+	return err
+}

--- a/tfexec/terraform_workspace_select.go
+++ b/tfexec/terraform_workspace_select.go
@@ -6,9 +6,8 @@ import (
 
 //WorkspaceSelect selects the workspace "workspace". The workspace needs to exist
 // in order for the switch to be successful
-func (c *terraformCLI) WorkspaceSelect(ctx context.Context, workspace string, dir string, opts ...string) error {
+func (c *terraformCLI) WorkspaceSelect(ctx context.Context, workspace string, dir string) error {
 	args := []string{"workspace", "select"}
-	args = append(args, opts...)
 	if len(workspace) > 0 {
 		args = append(args, workspace)
 	}

--- a/tfexec/terraform_workspace_select_test.go
+++ b/tfexec/terraform_workspace_select_test.go
@@ -33,6 +33,17 @@ func TestTerraformCLIWorkspaceSelect(t *testing.T) {
 			workspace: "foo",
 			ok:        true,
 		},
+		{
+			desc: "failed to run terraform workspace select",
+			mockCommands: []*mockCommand{
+				{
+					args:     []string{"terraform", "workspace", "select", "foo"},
+					exitCode: 1,
+				},
+			},
+			workspace: "foo",
+			ok:        false,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/tfexec/terraform_workspace_select_test.go
+++ b/tfexec/terraform_workspace_select_test.go
@@ -1,0 +1,63 @@
+package tfexec
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTerraformCLIWorkspaceSelect(t *testing.T) {
+	cases := []struct {
+		desc         string
+		mockCommands []*mockCommand
+		workspace    string
+		dir          string
+		ok           bool
+	}{
+		{
+			desc: "no workspace and no dir",
+			mockCommands: []*mockCommand{
+				{
+					args:     []string{"terraform", "workspace", "select"},
+					exitCode: 1,
+				},
+			},
+			ok: false,
+		},
+		{
+			desc: "with existing workspace",
+			mockCommands: []*mockCommand{
+				{
+					args:     []string{"terraform", "workspace", "select", "foo"},
+					exitCode: 0,
+				},
+			},
+			workspace: "foo",
+			ok:        true,
+		},
+		{
+			desc: "with workspace and dir",
+			mockCommands: []*mockCommand{
+				{
+					args:     []string{"terraform", "workspace", "select", "foo", "bar"},
+					exitCode: 0,
+				},
+			},
+			workspace: "foo",
+			dir:       "bar",
+			ok:        true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			e := NewMockExecutor(tc.mockCommands)
+			terraformCLI := NewTerraformCLI(e)
+			err := terraformCLI.WorkspaceSelect(context.Background(), tc.workspace, tc.dir)
+			if tc.ok && err != nil {
+				t.Fatalf("unexpected err: %s", err)
+			}
+			if !tc.ok && err == nil {
+				t.Fatal("expected to return an error, but no error")
+			}
+		})
+	}
+}

--- a/tfexec/terraform_workspace_select_test.go
+++ b/tfexec/terraform_workspace_select_test.go
@@ -10,7 +10,6 @@ func TestTerraformCLIWorkspaceSelect(t *testing.T) {
 		desc         string
 		mockCommands []*mockCommand
 		workspace    string
-		dir          string
 		ok           bool
 	}{
 		{
@@ -34,24 +33,12 @@ func TestTerraformCLIWorkspaceSelect(t *testing.T) {
 			workspace: "foo",
 			ok:        true,
 		},
-		{
-			desc: "with workspace and dir",
-			mockCommands: []*mockCommand{
-				{
-					args:     []string{"terraform", "workspace", "select", "foo", "bar"},
-					exitCode: 0,
-				},
-			},
-			workspace: "foo",
-			dir:       "bar",
-			ok:        true,
-		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 			e := NewMockExecutor(tc.mockCommands)
 			terraformCLI := NewTerraformCLI(e)
-			err := terraformCLI.WorkspaceSelect(context.Background(), tc.workspace, tc.dir)
+			err := terraformCLI.WorkspaceSelect(context.Background(), tc.workspace)
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err: %s", err)
 			}
@@ -74,12 +61,12 @@ func TestAccTerraformCLIWorkspaceSelect(t *testing.T) {
 		t.Fatalf("failed to run terraform init: %s", err)
 	}
 
-	err = terraformCLI.WorkspaceNew(context.Background(), "myworkspace", "")
+	err = terraformCLI.WorkspaceNew(context.Background(), "myworkspace")
 	if err != nil {
 		t.Fatalf("failed to create a new workspace: %s", err)
 	}
 
-	err = terraformCLI.WorkspaceSelect(context.Background(), "default", "")
+	err = terraformCLI.WorkspaceSelect(context.Background(), "default")
 	if err != nil {
 		t.Fatalf("failed to switch back to default workspace: %s", err)
 	}
@@ -89,7 +76,7 @@ func TestAccTerraformCLIWorkspaceSelect(t *testing.T) {
 		t.Fatalf("failed to run terraform workspace show: %s", err)
 	}
 
-	if got == "" {
+	if got != "default" {
 		t.Error("The current workspace doesn't match the workspace that was just selected")
 	}
 }

--- a/tfexec/terraform_workspace_select_test.go
+++ b/tfexec/terraform_workspace_select_test.go
@@ -13,7 +13,7 @@ func TestTerraformCLIWorkspaceSelect(t *testing.T) {
 		ok           bool
 	}{
 		{
-			desc: "no workspace and no dir",
+			desc: "no workspace",
 			mockCommands: []*mockCommand{
 				{
 					args:     []string{"terraform", "workspace", "select"},

--- a/tfexec/terraform_workspace_show.go
+++ b/tfexec/terraform_workspace_show.go
@@ -1,0 +1,25 @@
+package tfexec
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+)
+
+// tfWorkspaceRe is a pattern to parse outputs from terraform workspace show.
+var tfWorkspaceRe = regexp.MustCompile(`^[a-zA-Z\d_-]{1,90}`)
+
+//WorkspaceShow returns the currently selected workspace
+func (c *terraformCLI) WorkspaceShow(ctx context.Context) (string, error) {
+	args := []string{"workspace", "show"}
+	stdout, _, err := c.Run(ctx, args...)
+	if err != nil {
+		return "", err
+	}
+
+	matched := tfWorkspaceRe.FindString(stdout)
+	if matched == "" {
+		return "", fmt.Errorf("failed to parse the current workspace : %s", stdout)
+	}
+	return matched, nil
+}

--- a/tfexec/terraform_workspace_show.go
+++ b/tfexec/terraform_workspace_show.go
@@ -2,12 +2,8 @@ package tfexec
 
 import (
 	"context"
-	"fmt"
-	"regexp"
+	"strings"
 )
-
-// tfWorkspaceRe is a pattern to parse outputs from terraform workspace show.
-var tfWorkspaceRe = regexp.MustCompile(`^[a-zA-Z\d_-]{1,90}`)
 
 //WorkspaceShow returns the currently selected workspace
 func (c *terraformCLI) WorkspaceShow(ctx context.Context) (string, error) {
@@ -16,10 +12,5 @@ func (c *terraformCLI) WorkspaceShow(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-
-	matched := tfWorkspaceRe.FindString(stdout)
-	if matched == "" {
-		return "", fmt.Errorf("failed to parse the current workspace : %s", stdout)
-	}
-	return matched, nil
+	return strings.TrimRight(stdout, "\n"), nil
 }

--- a/tfexec/terraform_workspace_show_test.go
+++ b/tfexec/terraform_workspace_show_test.go
@@ -1,0 +1,72 @@
+package tfexec
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestTerraformCLIWorkspaceShow(t *testing.T) {
+	cases := []struct {
+		desc         string
+		mockCommands []*mockCommand
+		want         string
+		ok           bool
+	}{
+		{
+			desc: "parse output of terraform workspace show",
+			mockCommands: []*mockCommand{
+				{
+					args:     []string{"terraform", "workspace", "show"},
+					stdout:   "default",
+					exitCode: 0,
+				},
+			},
+			want: "default",
+			ok:   true,
+		},
+		{
+			desc: "with existing workspace",
+			mockCommands: []*mockCommand{
+				{
+					args:     []string{"terraform", "workspace", "show"},
+					exitCode: 1,
+				},
+			},
+			want: "",
+			ok:   false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			e := NewMockExecutor(tc.mockCommands)
+			terraformCLI := NewTerraformCLI(e)
+			got, err := terraformCLI.WorkspaceShow(context.Background())
+			if tc.ok && err != nil {
+				t.Fatalf("unexpected err: %s", err)
+			}
+			if !tc.ok && err == nil {
+				t.Fatal("expected to return an error, but no error")
+			}
+			if tc.ok && got != tc.want {
+				t.Errorf("got: %s, want: %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAccTerraformCLIWorkspaceShow(t *testing.T) {
+	SkipUnlessAcceptanceTestEnabled(t)
+
+	e := NewExecutor("", os.Environ())
+	terraformCLI := NewTerraformCLI(e)
+	got, err := terraformCLI.WorkspaceShow(context.Background())
+	if err != nil {
+		t.Fatalf("failed to run terraform workspace show: %s", err)
+	}
+	if got != "default" {
+		t.Error("terraform workspace show should return the default workspace")
+	}
+	fmt.Printf("got = %s\n", got)
+}

--- a/tfexec/test_helper.go
+++ b/tfexec/test_helper.go
@@ -282,7 +282,7 @@ provider "aws" {
 
 // SetupTestAccWithApply is an acceptance test helper for initializing a
 // temporary work directory and applying a given source.
-func SetupTestAccWithApply(t *testing.T, source string) TerraformCLI {
+func SetupTestAccWithApply(t *testing.T, workspace string, source string) TerraformCLI {
 	t.Helper()
 
 	e := SetupTestAcc(t, source)
@@ -292,6 +292,14 @@ func SetupTestAccWithApply(t *testing.T, source string) TerraformCLI {
 	err := tf.Init(ctx, "", "-input=false", "-no-color")
 	if err != nil {
 		t.Fatalf("failed to run terraform init: %s", err)
+	}
+
+	//default workspace always exists so don't try to create it
+	if workspace != "default" {
+		err = tf.WorkspaceNew(ctx, workspace, "")
+		if err != nil {
+			t.Fatalf("failed to run terraform workspace new %s : %s", workspace, err)
+		}
 	}
 
 	err = tf.Apply(ctx, nil, "", "-input=false", "-no-color", "-auto-approve")

--- a/tfexec/test_helper.go
+++ b/tfexec/test_helper.go
@@ -296,7 +296,7 @@ func SetupTestAccWithApply(t *testing.T, workspace string, source string) Terraf
 
 	//default workspace always exists so don't try to create it
 	if workspace != "default" {
-		err = tf.WorkspaceNew(ctx, workspace, "")
+		err = tf.WorkspaceNew(ctx, workspace)
 		if err != nil {
 			t.Fatalf("failed to run terraform workspace new %s : %s", workspace, err)
 		}

--- a/tfmigrate/migrator.go
+++ b/tfmigrate/migrator.go
@@ -3,8 +3,10 @@ package tfmigrate
 import (
 	"context"
 	"log"
+	"os"
+	"path/filepath"
 
-	"github.com/minamijoyo/tfmigrate/tfexec"
+	"github.com/dhaven/tfmigrate/tfexec"
 )
 
 // Migrator abstracts migration operations.
@@ -21,8 +23,8 @@ type Migrator interface {
 }
 
 // setupWorkDir is a common helper function to setup work dir and returns the
-// current state and a swtich back function.
-func setupWorkDir(ctx context.Context, tf tfexec.TerraformCLI) (*tfexec.State, func(), error) {
+// current state and a switch back function.
+func setupWorkDir(ctx context.Context, tf tfexec.TerraformCLI, workspace string) (*tfexec.State, func(), error) {
 	// check if terraform command is available.
 	version, err := tf.Version(ctx)
 	if err != nil {
@@ -30,27 +32,33 @@ func setupWorkDir(ctx context.Context, tf tfexec.TerraformCLI) (*tfexec.State, f
 	}
 	log.Printf("[INFO] [migrator@%s] terraform version: %s\n", tf.Dir(), version)
 
-	// initialize work dir.
+	// create local workspace folder
+	path := filepath.Join(tf.Dir(), "terraform.tfstate.d", workspace)
+	log.Printf("[INFO] [migrator@%s] creating local workspace folder in: %s\n", tf.Dir(), path)
+	os.MkdirAll(path, os.ModePerm)
+	// init folder
 	log.Printf("[INFO] [migrator@%s] initialize work dir\n", tf.Dir())
 	err = tf.Init(ctx, "", "-input=false", "-no-color")
 	if err != nil {
 		return nil, nil, err
 	}
-
+	//switch to workspace
+	log.Printf("[INFO] [migrator@%s] switch to remote workspace %s\n", tf.Dir(), workspace)
+	err = tf.WorkspaceSelect(ctx, workspace)
+	if err != nil {
+		return nil, nil, err
+	}
 	// get the current remote state.
 	log.Printf("[INFO] [migrator@%s] get the current remote state\n", tf.Dir())
 	currentState, err := tf.StatePull(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// The -state flag for terraform command is not valid for remote state,
-	// so we need to switch the backend to local for temporary state operations.
+	//override backend to local
 	log.Printf("[INFO] [migrator@%s] override backend to local\n", tf.Dir())
-	switchBackToRemotekFunc, err := tf.OverrideBackendToLocal(ctx, "_tfmigrate_override.tf")
+	switchBackToRemotekFunc, err := tf.OverrideBackendToLocal(ctx, "_tfmigrate_override.tf", workspace)
 	if err != nil {
 		return nil, nil, err
 	}
-
 	return currentState, switchBackToRemotekFunc, nil
 }

--- a/tfmigrate/migrator.go
+++ b/tfmigrate/migrator.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/dhaven/tfmigrate/tfexec"
+	"github.com/minamijoyo/tfmigrate/tfexec"
 )
 
 // Migrator abstracts migration operations.
@@ -44,7 +44,7 @@ func setupWorkDir(ctx context.Context, tf tfexec.TerraformCLI, workspace string)
 	}
 	//switch to workspace
 	log.Printf("[INFO] [migrator@%s] switch to remote workspace %s\n", tf.Dir(), workspace)
-	err = tf.WorkspaceSelect(ctx, workspace)
+	err = tf.WorkspaceSelect(ctx, workspace, "")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/tfmigrate/migrator.go
+++ b/tfmigrate/migrator.go
@@ -3,8 +3,6 @@ package tfmigrate
 import (
 	"context"
 	"log"
-	"os"
-	"path/filepath"
 
 	"github.com/minamijoyo/tfmigrate/tfexec"
 )
@@ -32,10 +30,6 @@ func setupWorkDir(ctx context.Context, tf tfexec.TerraformCLI, workspace string)
 	}
 	log.Printf("[INFO] [migrator@%s] terraform version: %s\n", tf.Dir(), version)
 
-	// create local workspace folder
-	path := filepath.Join(tf.Dir(), "terraform.tfstate.d", workspace)
-	log.Printf("[INFO] [migrator@%s] creating local workspace folder in: %s\n", tf.Dir(), path)
-	os.MkdirAll(path, os.ModePerm)
 	// init folder
 	log.Printf("[INFO] [migrator@%s] initialize work dir\n", tf.Dir())
 	err = tf.Init(ctx, "", "-input=false", "-no-color")
@@ -44,7 +38,7 @@ func setupWorkDir(ctx context.Context, tf tfexec.TerraformCLI, workspace string)
 	}
 	//switch to workspace
 	log.Printf("[INFO] [migrator@%s] switch to remote workspace %s\n", tf.Dir(), workspace)
-	err = tf.WorkspaceSelect(ctx, workspace, "")
+	err = tf.WorkspaceSelect(ctx, workspace)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/tfmigrate/multi_state_migrator.go
+++ b/tfmigrate/multi_state_migrator.go
@@ -15,6 +15,10 @@ type MultiStateMigratorConfig struct {
 	FromDir string `hcl:"from_dir"`
 	// ToDir is a working directory where states of resources move to.
 	ToDir string `hcl:"to_dir"`
+	// FromWorkspace is a workspace within FromDir
+	FromWorkspace string `hcl:"from_workspace,optional"`
+	// ToWorkspace is a workspace within ToDir
+	ToWorkspace string `hcl:"to_workspace,optional"`
 	// Actions is a list of multi state action.
 	// action is a plain text for state operation.
 	// Valid formats are the following.
@@ -44,20 +48,21 @@ func (c *MultiStateMigratorConfig) NewMigrator(o *MigratorOption) (Migrator, err
 		actions = append(actions, action)
 	}
 
-	return NewMultiStateMigrator(c.FromDir, c.ToDir, actions, o, c.Force), nil
+	return NewMultiStateMigrator(c.FromDir, c.ToDir, c.FromWorkspace, c.ToWorkspace, actions, o, c.Force), nil
 }
 
 // MultiStateMigrator implements the Migrator interface.
 type MultiStateMigrator struct {
 	// fromTf is an instance of TerraformCLI which executes terraform command in a fromDir.
 	fromTf tfexec.TerraformCLI
-
 	// fromTf is an instance of TerraformCLI which executes terraform command in a toDir.
 	toTf tfexec.TerraformCLI
-
+	//fromWorkspace is the workspace from which the resource will be migrated
+	fromWorkspace string
+	//toWorkspace is the workspace to which the resource will be migrated
+	toWorkspace string
 	// actions is a list of multi state migration operations.
 	actions []MultiStateAction
-
 	// force operation in case of unexpected diff
 	force bool
 }
@@ -65,7 +70,7 @@ type MultiStateMigrator struct {
 var _ Migrator = (*MultiStateMigrator)(nil)
 
 // NewMultiStateMigrator returns a new MultiStateMigrator instance.
-func NewMultiStateMigrator(fromDir string, toDir string, actions []MultiStateAction, o *MigratorOption, force bool) *MultiStateMigrator {
+func NewMultiStateMigrator(fromDir string, toDir string, fromWorkspace string, toWorkspace string, actions []MultiStateAction, o *MigratorOption, force bool) *MultiStateMigrator {
 	fromTf := tfexec.NewTerraformCLI(tfexec.NewExecutor(fromDir, os.Environ()))
 	toTf := tfexec.NewTerraformCLI(tfexec.NewExecutor(toDir, os.Environ()))
 	if o != nil && len(o.ExecPath) > 0 {
@@ -74,10 +79,12 @@ func NewMultiStateMigrator(fromDir string, toDir string, actions []MultiStateAct
 	}
 
 	return &MultiStateMigrator{
-		fromTf:  fromTf,
-		toTf:    toTf,
-		actions: actions,
-		force:   force,
+		fromTf:        fromTf,
+		toTf:          toTf,
+		fromWorkspace: fromWorkspace,
+		toWorkspace:   toWorkspace,
+		actions:       actions,
+		force:         force,
 	}
 }
 
@@ -87,15 +94,14 @@ func NewMultiStateMigrator(fromDir string, toDir string, actions []MultiStateAct
 // the Migrator interface between a single and multi state migrator.
 func (m *MultiStateMigrator) plan(ctx context.Context) (*tfexec.State, *tfexec.State, error) {
 	// setup fromDir.
-	fromCurrentState, fromSwitchBackToRemotekFunc, err := setupWorkDir(ctx, m.fromTf)
+	fromCurrentState, fromSwitchBackToRemotekFunc, err := setupWorkDir(ctx, m.fromTf, m.fromWorkspace)
 	if err != nil {
 		return nil, nil, err
 	}
 	// switch back it to remote on exit.
 	defer fromSwitchBackToRemotekFunc()
-
 	// setup toDir.
-	toCurrentState, toSwitchBackToRemotekFunc, err := setupWorkDir(ctx, m.toTf)
+	toCurrentState, toSwitchBackToRemotekFunc, err := setupWorkDir(ctx, m.toTf, m.toWorkspace)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -113,7 +119,6 @@ func (m *MultiStateMigrator) plan(ctx context.Context) (*tfexec.State, *tfexec.S
 		fromCurrentState = tfexec.NewState(fromNewState.Bytes())
 		toCurrentState = tfexec.NewState(toNewState.Bytes())
 	}
-
 	// check if a plan in fromDir has no changes.
 	log.Printf("[INFO] [migrator@%s] check diffs\n", m.fromTf.Dir())
 	_, err = m.fromTf.Plan(ctx, fromCurrentState, "", "-input=false", "-no-color", "-detailed-exitcode")

--- a/tfmigrate/multi_state_migrator.go
+++ b/tfmigrate/multi_state_migrator.go
@@ -48,6 +48,14 @@ func (c *MultiStateMigratorConfig) NewMigrator(o *MigratorOption) (Migrator, err
 		actions = append(actions, action)
 	}
 
+	//use default workspace if not specified by user
+	if len(c.FromWorkspace) == 0 {
+		c.FromWorkspace = "default"
+	}
+	if len(c.ToWorkspace) == 0 {
+		c.ToWorkspace = "default"
+	}
+
 	return NewMultiStateMigrator(c.FromDir, c.ToDir, c.FromWorkspace, c.ToWorkspace, actions, o, c.Force), nil
 }
 

--- a/tfmigrate/multi_state_migrator_test.go
+++ b/tfmigrate/multi_state_migrator_test.go
@@ -17,12 +17,27 @@ func TestMultiStateMigratorConfigNewMigrator(t *testing.T) {
 		ok     bool
 	}{
 		{
-			desc: "valid",
+			desc: "valid and default workspace",
+			config: &MultiStateMigratorConfig{
+				FromDir: "dir1",
+				ToDir:   "dir2",
+				Actions: []string{
+					"mv aws_security_group.foo aws_security_group.foo2",
+					"mv aws_security_group.bar aws_security_group.bar2",
+				},
+			},
+			o: &MigratorOption{
+				ExecPath: "direnv exec . terraform",
+			},
+			ok: true,
+		},
+		{
+			desc: "valid and custom workspace",
 			config: &MultiStateMigratorConfig{
 				FromDir:       "dir1",
 				ToDir:         "dir2",
-				FromWorkspace: "default",
-				ToWorkspace:   "default",
+				FromWorkspace: "work1",
+				ToWorkspace:   "work2",
 				Actions: []string{
 					"mv aws_security_group.foo aws_security_group.foo2",
 					"mv aws_security_group.bar aws_security_group.bar2",
@@ -38,8 +53,8 @@ func TestMultiStateMigratorConfigNewMigrator(t *testing.T) {
 			config: &MultiStateMigratorConfig{
 				FromDir:       "dir1",
 				ToDir:         "dir2",
-				FromWorkspace: "default",
-				ToWorkspace:   "default",
+				FromWorkspace: "work1",
+				ToWorkspace:   "work2",
 				Actions: []string{
 					"mv aws_security_group.foo",
 				},
@@ -52,8 +67,8 @@ func TestMultiStateMigratorConfigNewMigrator(t *testing.T) {
 			config: &MultiStateMigratorConfig{
 				FromDir:       "dir1",
 				ToDir:         "dir2",
-				FromWorkspace: "default",
-				ToWorkspace:   "default",
+				FromWorkspace: "work1",
+				ToWorkspace:   "work2",
 				Actions:       []string{},
 			},
 			o:  nil,
@@ -64,8 +79,8 @@ func TestMultiStateMigratorConfigNewMigrator(t *testing.T) {
 			config: &MultiStateMigratorConfig{
 				FromDir:       "dir1",
 				ToDir:         "dir2",
-				FromWorkspace: "default",
-				ToWorkspace:   "default",
+				FromWorkspace: "work1",
+				ToWorkspace:   "work2",
 				Actions: []string{
 					"mv aws_security_group.foo aws_security_group.foo2",
 					"mv aws_security_group.bar aws_security_group.bar2",
@@ -98,19 +113,19 @@ func TestAccMultiStateMigratorApply(t *testing.T) {
 	ctx := context.Background()
 
 	fromBackend := tfexec.GetTestAccBackendS3Config(t.Name() + "/fromDir")
+	fromWorkspace := "work1"
 	fromSource := `
 resource "aws_security_group" "foo" {}
 resource "aws_security_group" "bar" {}
 resource "aws_security_group" "baz" {}
 `
-	fromTf := tfexec.SetupTestAccWithApply(t, fromBackend+fromSource)
-	fromWorkspace := "default"
+	fromTf := tfexec.SetupTestAccWithApply(t, fromWorkspace, fromBackend+fromSource)
 	toBackend := tfexec.GetTestAccBackendS3Config(t.Name() + "/toDir")
+	toWorkspace := "work2"
 	toSource := `
 resource "aws_security_group" "qux" {}
 `
-	toTf := tfexec.SetupTestAccWithApply(t, toBackend+toSource)
-	toWorkspace := "default"
+	toTf := tfexec.SetupTestAccWithApply(t, toWorkspace, toBackend+toSource)
 	fromUpdatedSource := `
 resource "aws_security_group" "baz" {}
 `
@@ -201,19 +216,19 @@ func TestAccMultiStateMigratorApplyForce(t *testing.T) {
 	ctx := context.Background()
 
 	fromBackend := tfexec.GetTestAccBackendS3Config(t.Name() + "/fromDir")
+	fromWorkspace := "work1"
 	fromSource := `
 resource "aws_security_group" "foo" {}
 resource "aws_security_group" "bar" {}
 resource "aws_security_group" "baz" {}
 `
-	fromTf := tfexec.SetupTestAccWithApply(t, fromBackend+fromSource)
-	fromWorkspace := "default"
+	fromTf := tfexec.SetupTestAccWithApply(t, fromWorkspace, fromBackend+fromSource)
+	toWorkspace := "work2"
 	toBackend := tfexec.GetTestAccBackendS3Config(t.Name() + "/toDir")
 	toSource := `
 resource "aws_security_group" "qux" {}
 `
-	toTf := tfexec.SetupTestAccWithApply(t, toBackend+toSource)
-	toWorkspace := "default"
+	toTf := tfexec.SetupTestAccWithApply(t, toWorkspace, toBackend+toSource)
 	fromUpdatedSource := `
 resource "aws_security_group" "baz" {}
 `

--- a/tfmigrate/multi_state_migrator_test.go
+++ b/tfmigrate/multi_state_migrator_test.go
@@ -110,207 +110,208 @@ func TestMultiStateMigratorConfigNewMigrator(t *testing.T) {
 
 func TestAccMultiStateMigratorApply(t *testing.T) {
 	tfexec.SkipUnlessAcceptanceTestEnabled(t)
-	ctx := context.Background()
+	cases := []struct {
+		desc                  string
+		fromWorkspace         string
+		fromSource            string
+		fromUpdatedSource     string
+		fromUpdatedState      []string
+		fromStateExpectChange bool
+		toWorkspace           string
+		toSource              string
+		toUpdatedSource       string
+		toUpdatedState        []string
+		toStateExpectChange   bool
+		actions               []string
+		force                 bool
+	}{
+		{
+			desc:          "multi-state migration between default workspaces",
+			fromWorkspace: "default",
+			fromSource: `
+			resource "aws_security_group" "foo" {}
+			resource "aws_security_group" "bar" {}
+			resource "aws_security_group" "baz" {}
+			`,
+			fromUpdatedSource: `
+			resource "aws_security_group" "baz" {}
+			`,
+			fromUpdatedState: []string{
+				"aws_security_group.baz",
+			},
+			fromStateExpectChange: false,
+			toWorkspace:           "default",
+			toSource: `
+			resource "aws_security_group" "qux" {}
+			`,
+			toUpdatedSource: `
+			resource "aws_security_group" "foo" {}
+			resource "aws_security_group" "bar2" {}
+			resource "aws_security_group" "qux" {}
+			`,
+			toUpdatedState: []string{
+				"aws_security_group.foo",
+				"aws_security_group.bar2",
+				"aws_security_group.qux",
+			},
+			toStateExpectChange: false,
+			actions: []string{
+				"mv aws_security_group.foo aws_security_group.foo",
+				"mv aws_security_group.bar aws_security_group.bar2",
+			},
+			force: false,
+		},
+		{
+			desc:          "multi-state migration between default workspaces with force == true",
+			fromWorkspace: "default",
+			fromSource: `
+			resource "aws_security_group" "foo" {}
+			resource "aws_security_group" "bar" {}
+			resource "aws_security_group" "baz" {}
+			`,
+			fromUpdatedSource: `
+			resource "aws_security_group" "baz" {}
+			`,
+			fromUpdatedState: []string{
+				"aws_security_group.baz",
+			},
+			fromStateExpectChange: false,
+			toWorkspace:           "default",
+			toSource: `
+			resource "aws_security_group" "qux" {}
+			`,
+			toUpdatedSource: `
+			resource "aws_security_group" "foo" {}
+			resource "aws_security_group" "bar2" {}
+			resource "aws_security_group" "qux" {}
+			resource "aws_security_group" "qux2" {}
+			`,
+			toUpdatedState: []string{
+				"aws_security_group.foo",
+				"aws_security_group.bar2",
+				"aws_security_group.qux",
+			},
+			toStateExpectChange: true,
+			actions: []string{
+				"mv aws_security_group.foo aws_security_group.foo",
+				"mv aws_security_group.bar aws_security_group.bar2",
+			},
+			force: true,
+		},
+		{
+			desc:          "multi-state migration between user-defined workspaces",
+			fromWorkspace: "work1",
+			fromSource: `
+			resource "aws_security_group" "foo" {}
+			resource "aws_security_group" "bar" {}
+			resource "aws_security_group" "baz" {}
+			`,
+			fromUpdatedSource: `
+			resource "aws_security_group" "baz" {}
+			`,
+			fromUpdatedState: []string{
+				"aws_security_group.baz",
+			},
+			fromStateExpectChange: false,
+			toWorkspace:           "work2",
+			toSource: `
+			resource "aws_security_group" "qux" {}
+			`,
+			toUpdatedSource: `
+			resource "aws_security_group" "foo" {}
+			resource "aws_security_group" "bar2" {}
+			resource "aws_security_group" "qux" {}
+			`,
+			toUpdatedState: []string{
+				"aws_security_group.foo",
+				"aws_security_group.bar2",
+				"aws_security_group.qux",
+			},
+			toStateExpectChange: false,
+			actions: []string{
+				"mv aws_security_group.foo aws_security_group.foo",
+				"mv aws_security_group.bar aws_security_group.bar2",
+			},
+			force: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			ctx := context.Background()
+			//setup the initial files and states
+			fromBackend := tfexec.GetTestAccBackendS3Config(t.Name() + "/fromDir")
+			fromTf := tfexec.SetupTestAccWithApply(t, tc.fromWorkspace, fromBackend+tc.fromSource)
+			toBackend := tfexec.GetTestAccBackendS3Config(t.Name() + "/toDir")
+			toTf := tfexec.SetupTestAccWithApply(t, tc.toWorkspace, toBackend+tc.toSource)
+			//update terraform resource files for migration
+			tfexec.UpdateTestAccSource(t, fromTf, fromBackend+tc.fromUpdatedSource)
+			tfexec.UpdateTestAccSource(t, toTf, toBackend+tc.toUpdatedSource)
+			changed, err := fromTf.PlanHasChange(ctx, nil, "")
+			if err != nil {
+				t.Fatalf("failed to run PlanHasChange in fromDir: %s", err)
+			}
+			if !changed {
+				t.Fatalf("expect to have changes in fromDir")
+			}
+			changed, err = toTf.PlanHasChange(ctx, nil, "")
+			if err != nil {
+				t.Fatalf("failed to run PlanHasChange in toDir: %s", err)
+			}
+			if !changed {
+				t.Fatalf("expect to have changes in toDir")
+			}
+			//perform state migration
+			actions := []MultiStateAction{}
+			for _, cmdStr := range tc.actions {
+				action, err := NewMultiStateActionFromString(cmdStr)
+				if err != nil {
+					t.Fatalf("unable to parse migration action")
+				}
+				actions = append(actions, action)
+			}
+			m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), tc.fromWorkspace, tc.toWorkspace, actions, nil, tc.force)
+			err = m.Plan(ctx)
+			if err != nil {
+				t.Fatalf("failed to run migrator plan: %s", err)
+			}
 
-	fromBackend := tfexec.GetTestAccBackendS3Config(t.Name() + "/fromDir")
-	fromWorkspace := "work1"
-	fromSource := `
-resource "aws_security_group" "foo" {}
-resource "aws_security_group" "bar" {}
-resource "aws_security_group" "baz" {}
-`
-	fromTf := tfexec.SetupTestAccWithApply(t, fromWorkspace, fromBackend+fromSource)
-	toBackend := tfexec.GetTestAccBackendS3Config(t.Name() + "/toDir")
-	toWorkspace := "work2"
-	toSource := `
-resource "aws_security_group" "qux" {}
-`
-	toTf := tfexec.SetupTestAccWithApply(t, toWorkspace, toBackend+toSource)
-	fromUpdatedSource := `
-resource "aws_security_group" "baz" {}
-`
-	tfexec.UpdateTestAccSource(t, fromTf, fromBackend+fromUpdatedSource)
-	toUpdatedSource := `
-resource "aws_security_group" "foo" {}
-resource "aws_security_group" "bar2" {}
-resource "aws_security_group" "qux" {}
-`
-	tfexec.UpdateTestAccSource(t, toTf, toBackend+toUpdatedSource)
-
-	changed, err := fromTf.PlanHasChange(ctx, nil, "")
-	if err != nil {
-		t.Fatalf("failed to run PlanHasChange in fromDir: %s", err)
-	}
-	if !changed {
-		t.Fatalf("expect to have changes in fromDir")
-	}
-	changed, err = toTf.PlanHasChange(ctx, nil, "")
-	if err != nil {
-		t.Fatalf("failed to run PlanHasChange in toDir: %s", err)
-	}
-	if !changed {
-		t.Fatalf("expect to have changes in toDir")
-	}
-
-	actions := []MultiStateAction{
-		NewMultiStateMvAction("aws_security_group.foo", "aws_security_group.foo"),
-		NewMultiStateMvAction("aws_security_group.bar", "aws_security_group.bar2"),
-	}
-
-	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, nil, false)
-	err = m.Plan(ctx)
-	if err != nil {
-		t.Fatalf("failed to run migrator plan: %s", err)
-	}
-
-	err = m.Apply(ctx)
-	if err != nil {
-		t.Fatalf("failed to run migrator apply: %s", err)
-	}
-
-	fromGot, err := fromTf.StateList(ctx, nil, nil)
-	if err != nil {
-		t.Fatalf("failed to run terraform state list in fromDir: %s", err)
-	}
-	fromWant := []string{
-		"aws_security_group.baz",
-	}
-	sort.Strings(fromGot)
-	sort.Strings(fromWant)
-	if !reflect.DeepEqual(fromGot, fromWant) {
-		t.Errorf("got state: %v, want state: %v in fromDir", fromGot, fromWant)
-	}
-	toGot, err := toTf.StateList(ctx, nil, nil)
-	if err != nil {
-		t.Fatalf("failed to run terraform state list in toDir: %s", err)
-	}
-	toWant := []string{
-		"aws_security_group.foo",
-		"aws_security_group.bar2",
-		"aws_security_group.qux",
-	}
-	sort.Strings(toGot)
-	sort.Strings(toWant)
-	if !reflect.DeepEqual(toGot, toWant) {
-		t.Errorf("got state: %v, want state: %v in toDir", toGot, toWant)
-	}
-
-	changed, err = fromTf.PlanHasChange(ctx, nil, "")
-	if err != nil {
-		t.Fatalf("failed to run PlanHasChange in fromDir: %s", err)
-	}
-	if changed {
-		t.Fatalf("expect not to have changes in fromDir")
-	}
-	changed, err = toTf.PlanHasChange(ctx, nil, "")
-	if err != nil {
-		t.Fatalf("failed to run PlanHasChange in toDir: %s", err)
-	}
-	if changed {
-		t.Fatalf("expect not to have changes in toDir")
-	}
-}
-
-func TestAccMultiStateMigratorApplyForce(t *testing.T) {
-	tfexec.SkipUnlessAcceptanceTestEnabled(t)
-	ctx := context.Background()
-
-	fromBackend := tfexec.GetTestAccBackendS3Config(t.Name() + "/fromDir")
-	fromWorkspace := "work1"
-	fromSource := `
-resource "aws_security_group" "foo" {}
-resource "aws_security_group" "bar" {}
-resource "aws_security_group" "baz" {}
-`
-	fromTf := tfexec.SetupTestAccWithApply(t, fromWorkspace, fromBackend+fromSource)
-	toWorkspace := "work2"
-	toBackend := tfexec.GetTestAccBackendS3Config(t.Name() + "/toDir")
-	toSource := `
-resource "aws_security_group" "qux" {}
-`
-	toTf := tfexec.SetupTestAccWithApply(t, toWorkspace, toBackend+toSource)
-	fromUpdatedSource := `
-resource "aws_security_group" "baz" {}
-`
-	tfexec.UpdateTestAccSource(t, fromTf, fromBackend+fromUpdatedSource)
-	toUpdatedSource := `
-resource "aws_security_group" "foo" {}
-resource "aws_security_group" "bar2" {}
-resource "aws_security_group" "qux" {}
-resource "aws_security_group" "qux2" {}
-`
-	tfexec.UpdateTestAccSource(t, toTf, toBackend+toUpdatedSource)
-
-	changed, err := fromTf.PlanHasChange(ctx, nil, "")
-	if err != nil {
-		t.Fatalf("failed to run PlanHasChange in fromDir: %s", err)
-	}
-	if !changed {
-		t.Fatalf("expect to have changes in fromDir")
-	}
-	changed, err = toTf.PlanHasChange(ctx, nil, "")
-	if err != nil {
-		t.Fatalf("failed to run PlanHasChange in toDir: %s", err)
-	}
-	if !changed {
-		t.Fatalf("expect to have changes in toDir")
-	}
-
-	actions := []MultiStateAction{
-		NewMultiStateMvAction("aws_security_group.foo", "aws_security_group.foo"),
-		NewMultiStateMvAction("aws_security_group.bar", "aws_security_group.bar2"),
-	}
-
-	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, nil, true)
-	err = m.Plan(ctx)
-	if err != nil {
-		t.Fatalf("failed to run migrator plan: %s", err)
-	}
-
-	err = m.Apply(ctx)
-	if err != nil {
-		t.Fatalf("failed to run migrator apply: %s", err)
-	}
-
-	fromGot, err := fromTf.StateList(ctx, nil, nil)
-	if err != nil {
-		t.Fatalf("failed to run terraform state list in fromDir: %s", err)
-	}
-	fromWant := []string{
-		"aws_security_group.baz",
-	}
-	sort.Strings(fromGot)
-	sort.Strings(fromWant)
-	if !reflect.DeepEqual(fromGot, fromWant) {
-		t.Errorf("got state: %v, want state: %v in fromDir", fromGot, fromWant)
-	}
-	toGot, err := toTf.StateList(ctx, nil, nil)
-	if err != nil {
-		t.Fatalf("failed to run terraform state list in toDir: %s", err)
-	}
-	toWant := []string{
-		"aws_security_group.foo",
-		"aws_security_group.bar2",
-		"aws_security_group.qux",
-	}
-	sort.Strings(toGot)
-	sort.Strings(toWant)
-	if !reflect.DeepEqual(toGot, toWant) {
-		t.Errorf("got state: %v, want state: %v in toDir", toGot, toWant)
-	}
-
-	changed, err = fromTf.PlanHasChange(ctx, nil, "")
-	if err != nil {
-		t.Fatalf("failed to run PlanHasChange in fromDir: %s", err)
-	}
-	if changed {
-		t.Fatalf("expect not to have changes in fromDir")
-	}
-	changed, err = toTf.PlanHasChange(ctx, nil, "")
-	if err != nil {
-		t.Fatalf("failed to run PlanHasChange in toDir: %s", err)
-	}
-	if !changed {
-		t.Fatalf("expect to have changes in toDir")
+			err = m.Apply(ctx)
+			if err != nil {
+				t.Fatalf("failed to run migrator apply: %s", err)
+			}
+			//verify state migration results
+			fromGot, err := fromTf.StateList(ctx, nil, nil)
+			if err != nil {
+				t.Fatalf("failed to run terraform state list in fromDir: %s", err)
+			}
+			sort.Strings(fromGot)
+			sort.Strings(tc.fromUpdatedState)
+			if !reflect.DeepEqual(fromGot, tc.fromUpdatedState) {
+				t.Errorf("got state: %v, want state: %v in fromDir", fromGot, tc.fromUpdatedState)
+			}
+			toGot, err := toTf.StateList(ctx, nil, nil)
+			if err != nil {
+				t.Fatalf("failed to run terraform state list in toDir: %s", err)
+			}
+			sort.Strings(toGot)
+			sort.Strings(tc.toUpdatedState)
+			if !reflect.DeepEqual(toGot, tc.toUpdatedState) {
+				t.Errorf("got state: %v, want state: %v in toDir", toGot, tc.toUpdatedState)
+			}
+			changed, err = fromTf.PlanHasChange(ctx, nil, "")
+			if err != nil {
+				t.Fatalf("failed to run PlanHasChange in fromDir: %s", err)
+			}
+			if changed != tc.fromStateExpectChange {
+				t.Fatalf("expected change in fromDir is %t but actual value is %t", tc.fromStateExpectChange, changed)
+			}
+			changed, err = toTf.PlanHasChange(ctx, nil, "")
+			if err != nil {
+				t.Fatalf("failed to run PlanHasChange in toDir: %s", err)
+			}
+			if changed != tc.toStateExpectChange {
+				t.Fatalf("expected change in toDir is %t but actual value is %t", tc.toStateExpectChange, changed)
+			}
+		})
 	}
 }

--- a/tfmigrate/state_import_action_test.go
+++ b/tfmigrate/state_import_action_test.go
@@ -23,7 +23,7 @@ resource "aws_iam_user" "baz" {
 	name = "baz"
 }
 `
-	tf := tfexec.SetupTestAccWithApply(t, backend+source)
+	tf := tfexec.SetupTestAccWithApply(t, "default", backend+source)
 	ctx := context.Background()
 
 	_, err := tf.StateRm(ctx, nil, []string{"aws_iam_user.foo", "aws_iam_user.baz"})

--- a/tfmigrate/state_migrator.go
+++ b/tfmigrate/state_migrator.go
@@ -80,7 +80,7 @@ func NewStateMigrator(dir string, actions []StateAction, o *MigratorOption, forc
 	return &StateMigrator{
 		tf:      tf,
 		actions: actions,
-		force: force,
+		force:   force,
 	}
 }
 
@@ -90,7 +90,7 @@ func NewStateMigrator(dir string, actions []StateAction, o *MigratorOption, forc
 // the Migrator interface between a single and multi state migrator.
 func (m *StateMigrator) plan(ctx context.Context) (*tfexec.State, error) {
 	// setup work dir.
-	currentState, switchBackToRemotekFunc, err := setupWorkDir(ctx, m.tf)
+	currentState, switchBackToRemotekFunc, err := setupWorkDir(ctx, m.tf, "default")
 	if err != nil {
 		return nil, err
 	}

--- a/tfmigrate/state_migrator_test.go
+++ b/tfmigrate/state_migrator_test.go
@@ -80,7 +80,7 @@ func TestStateMigratorConfigNewMigrator(t *testing.T) {
 				},
 				Force: true,
 			},
-			o: nil,
+			o:  nil,
 			ok: true,
 		},
 	}
@@ -114,7 +114,7 @@ resource "aws_iam_user" "qux" {
 	name = "qux"
 }
 `
-	tf := tfexec.SetupTestAccWithApply(t, backend+source)
+	tf := tfexec.SetupTestAccWithApply(t, "default", backend+source)
 	ctx := context.Background()
 
 	updatedSource := `
@@ -191,7 +191,7 @@ func TestAccStateMigratorApplyForce(t *testing.T) {
 resource "aws_security_group" "foo" {}
 resource "aws_security_group" "bar" {}
 `
-	tf := tfexec.SetupTestAccWithApply(t, backend+source)
+	tf := tfexec.SetupTestAccWithApply(t, "default", backend+source)
 	ctx := context.Background()
 
 	updatedSource := `

--- a/tfmigrate/state_mv_action_test.go
+++ b/tfmigrate/state_mv_action_test.go
@@ -17,7 +17,7 @@ resource "aws_security_group" "foo" {}
 resource "aws_security_group" "bar" {}
 resource "aws_security_group" "baz" {}
 `
-	tf := tfexec.SetupTestAccWithApply(t, backend+source)
+	tf := tfexec.SetupTestAccWithApply(t, "default", backend+source)
 	ctx := context.Background()
 
 	updatedSource := `

--- a/tfmigrate/state_rm_action_test.go
+++ b/tfmigrate/state_rm_action_test.go
@@ -18,7 +18,7 @@ resource "aws_security_group" "bar" {}
 resource "aws_security_group" "baz" {}
 resource "aws_security_group" "qux" {}
 `
-	tf := tfexec.SetupTestAccWithApply(t, backend+source)
+	tf := tfexec.SetupTestAccWithApply(t, "default", backend+source)
 	ctx := context.Background()
 
 	updatedSource := `


### PR DESCRIPTION
Implements the workspace feature request from #3 

Main logic is in setupWorkDir() where I create the local workspace folder required before calling OverrideBackendToLocal()

Would love some feedback on this PR @minamijoyo 