### PR TITLE
Add a new flag --out for saving a plan file after dry-run migrations

### DIFF
--- a/command/plan.go
+++ b/command/plan.go
@@ -13,12 +13,14 @@ import (
 // migration operations to a temporary state.
 type PlanCommand struct {
 	Meta
+	out string
 }
 
 // Run runs the procedure of this command.
 func (c *PlanCommand) Run(args []string) int {
 	cmdFlags := flag.NewFlagSet("plan", flag.ContinueOnError)
 	cmdFlags.StringVar(&c.configFile, "config", defaultConfigFile, "A path to tfmigrate config file")
+	cmdFlags.StringVar(&c.out, "out", "", "Save a plan file after dry-run migration to the given path")
 
 	if err := cmdFlags.Parse(args); err != nil {
 		c.UI.Error(fmt.Sprintf("failed to parse arguments: %s", err))
@@ -33,6 +35,7 @@ func (c *PlanCommand) Run(args []string) int {
 	log.Printf("[DEBUG] [command] config: %#v\n", c.config)
 
 	c.Option = newOption()
+	c.Option.PlanOut = c.out
 	// The option may contains sensitive values such as environment variables.
 	// So logging the option set log level to DEBUG instead of INFO.
 	log.Printf("[DEBUG] [command] option: %#v\n", c.Option)
@@ -111,6 +114,9 @@ Arguments:
 
 Options:
   --config           A path to tfmigrate config file
+  --out=path         Save a plan file after dry-run migration to the given path.
+                     Note that applying the plan file only affects a local state,
+                     make sure to force push it to remote after terraform apply.
 `
 	return strings.TrimSpace(helpText)
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/google/go-cmp v0.5.2
 	github.com/hashicorp/aws-sdk-go-base v0.6.0
+	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/hcl/v2 v2.6.0
 	github.com/hashicorp/logutils v1.0.0
 	github.com/mattn/go-shellwords v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6K
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
+github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl/v2 v2.6.0 h1:3krZOfGY6SziUXa6H9PJU6TyohHn7I+ARYnhbeNBz+o=
 github.com/hashicorp/hcl/v2 v2.6.0/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=

--- a/tfexec/terraform.go
+++ b/tfexec/terraform.go
@@ -320,3 +320,13 @@ func hasPrefixOptions(opts []string, prefix string) bool {
 	}
 	return false
 }
+
+// getOptionValue returns a value if any element in a list of options has a given prefix.
+func getOptionValue(opts []string, prefix string) string {
+	for _, opt := range opts {
+		if strings.HasPrefix(opt, prefix) {
+			return opt[len(prefix):]
+		}
+	}
+	return ""
+}

--- a/tfexec/terraform_plan.go
+++ b/tfexec/terraform_plan.go
@@ -24,21 +24,24 @@ func (c *terraformCLI) Plan(ctx context.Context, state *State, dir string, opts 
 		args = append(args, "-state="+tmpState.Name())
 	}
 
-	// disallow -out option for writing a plan file to a temporary file and load it to memory
+	// To return a plan file as a return value, we always use an -out option and load it to memory.
+	// if the option exists just use it else create a temporary file.
+	planOut := ""
 	if hasPrefixOptions(opts, "-out=") {
-		return nil, fmt.Errorf("failed to build options. The -out= option is not allowed. Read a return value: %v", opts)
-	}
+		planOut = getOptionValue(opts, "-out=")
+	} else {
+		tmpPlan, err := ioutil.TempFile("", "tfplan")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create temporary plan file: %s", err)
+		}
+		planOut = tmpPlan.Name()
+		defer os.Remove(planOut)
 
-	tmpPlan, err := ioutil.TempFile("", "tfplan")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create temporary plan file: %s", err)
+		if err := tmpPlan.Close(); err != nil {
+			return nil, fmt.Errorf("failed to close temporary plan file: %s", err)
+		}
+		args = append(args, "-out="+planOut)
 	}
-	defer os.Remove(tmpPlan.Name())
-
-	if err := tmpPlan.Close(); err != nil {
-		return nil, fmt.Errorf("failed to close temporary plan file: %s", err)
-	}
-	args = append(args, "-out="+tmpPlan.Name())
 
 	args = append(args, opts...)
 
@@ -46,11 +49,11 @@ func (c *terraformCLI) Plan(ctx context.Context, state *State, dir string, opts 
 		args = append(args, dir)
 	}
 
-	_, _, err = c.Run(ctx, args...)
+	_, _, err := c.Run(ctx, args...)
 
 	// terraform plan -detailed-exitcode returns 2 if there is a diff.
 	// So we intentionally ignore an error of read the plan file and returns the
 	// original error of terraform plan command.
-	plan, _ := ioutil.ReadFile(tmpPlan.Name())
+	plan, _ := ioutil.ReadFile(planOut)
 	return NewPlan(plan), err
 }

--- a/tfexec/terraform_test.go
+++ b/tfexec/terraform_test.go
@@ -196,3 +196,34 @@ func TestAccTerraformCLIPlanHasChange(t *testing.T) {
 		t.Fatalf("expect to have changes")
 	}
 }
+
+func TestGetOptionValue(t *testing.T) {
+	cases := []struct {
+		desc   string
+		opts   []string
+		prefix string
+		want   string
+	}{
+		{
+			desc:   "found",
+			opts:   []string{"-input=false", "-no-color", "-out=foo.tfplan", "-detailed-exitcode"},
+			prefix: "-out=",
+			want:   "foo.tfplan",
+		},
+		{
+			desc:   "not found",
+			opts:   []string{"-input=false", "-no-color", "-detailed-exitcode"},
+			prefix: "-out=",
+			want:   "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := getOptionValue(tc.opts, tc.prefix)
+			if got != tc.want {
+				t.Errorf("got: %s, want: %s", got, tc.want)
+			}
+		})
+	}
+}

--- a/tfexec/test_helper.go
+++ b/tfexec/test_helper.go
@@ -11,6 +11,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/go-version"
 )
 
 // mockExecutor impolements the Executor interface for testing.
@@ -324,4 +326,21 @@ func UpdateTestAccSource(t *testing.T, tf TerraformCLI, source string) {
 	if err := ioutil.WriteFile(filepath.Join(tf.Dir(), testAccSourceFileName), []byte(source), 0644); err != nil {
 		t.Fatalf("failed to update source: %s", err)
 	}
+}
+
+// MatchTerraformVersion returns true if terraform version matches a given constraints.
+func MatchTerraformVersion(ctx context.Context, tf TerraformCLI, constraints string) (bool, error) {
+	tfVersionRaw, err := tf.Version(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to get terraform version: %s", err)
+	}
+	v, err := version.NewVersion(tfVersionRaw)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse terraform version: %s", err)
+	}
+	c, err := version.NewConstraint(constraints)
+	if err != nil {
+		return false, fmt.Errorf("failed to new version constraint: %s", err)
+	}
+	return c.Check(v), nil
 }

--- a/tfmigrate/config.go
+++ b/tfmigrate/config.go
@@ -24,4 +24,7 @@ type MigratorOption struct {
 	// It's intended to inject a wrapper command such as direnv.
 	// e.g.) direnv exec . terraform
 	ExecPath string
+
+	// PlanOut is a path to plan file to be saved.
+	PlanOut string
 }

--- a/tfmigrate/multi_state_migrator_test.go
+++ b/tfmigrate/multi_state_migrator_test.go
@@ -344,6 +344,23 @@ func TestAccMultiStateMigratorApply(t *testing.T) {
 					t.Fatalf("failed to apply the saved plan file in toDir: %s", err)
 				}
 
+				// Terraform >= v0.12.25 and < v0.13 has a bug for state push -force
+				// https://github.com/hashicorp/terraform/issues/25761
+				fromTfVersionMatched, err := tfexec.MatchTerraformVersion(ctx, fromTf, ">= 0.12.25, < 0.13")
+				if err != nil {
+					t.Fatalf("failed to check terraform version constraints in fromDir: %s", err)
+				}
+				if fromTfVersionMatched {
+					t.Skip("skip the following test due to a bug in Terraform v0.12")
+				}
+				toTfVersionMatched, err := tfexec.MatchTerraformVersion(ctx, toTf, ">= 0.12.25, < 0.13")
+				if err != nil {
+					t.Fatalf("failed to check terraform version constraints in toDir: %s", err)
+				}
+				if toTfVersionMatched {
+					t.Skip("skip the following test due to a bug in Terraform v0.12")
+				}
+
 				// Note that applying the plan file only affects a local state,
 				// make sure to force push it to remote after terraform apply.
 				// The -force flag is required here because the lineage of the state was changed.

--- a/tfmigrate/state_import_action_test.go
+++ b/tfmigrate/state_import_action_test.go
@@ -44,7 +44,7 @@ resource "aws_iam_user" "baz" {
 		NewStateImportAction("aws_iam_user.baz", "baz"),
 	}
 
-	m := NewStateMigrator(tf.Dir(), actions, nil, false)
+	m := NewStateMigrator(tf.Dir(), actions, &MigratorOption{}, false)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)

--- a/tfmigrate/state_migrator_test.go
+++ b/tfmigrate/state_migrator_test.go
@@ -263,6 +263,16 @@ resource "aws_security_group" "baz" {}
 		t.Fatalf("failed to apply the saved plan file: %s", err)
 	}
 
+	// Terraform >= v0.12.25 and < v0.13 has a bug for state push -force
+	// https://github.com/hashicorp/terraform/issues/25761
+	tfVersionMatched, err := tfexec.MatchTerraformVersion(ctx, tf, ">= 0.12.25, < 0.13")
+	if err != nil {
+		t.Fatalf("failed to check terraform version constraints: %s", err)
+	}
+	if tfVersionMatched {
+		t.Skip("skip the following test due to a bug in Terraform v0.12")
+	}
+
 	// Note that applying the plan file only affects a local state,
 	// make sure to force push it to remote after terraform apply.
 	// The -force flag is required here because the lineage of the state was changed.

--- a/tfmigrate/state_mv_action_test.go
+++ b/tfmigrate/state_mv_action_test.go
@@ -41,7 +41,7 @@ resource "aws_security_group" "baz" {}
 		NewStateMvAction("aws_security_group.bar", "aws_security_group.bar2"),
 	}
 
-	m := NewStateMigrator(tf.Dir(), actions, nil, false)
+	m := NewStateMigrator(tf.Dir(), actions, &MigratorOption{}, false)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)

--- a/tfmigrate/state_rm_action_test.go
+++ b/tfmigrate/state_rm_action_test.go
@@ -40,7 +40,7 @@ resource "aws_security_group" "baz" {}
 		NewStateRmAction([]string{"aws_security_group.qux"}),
 	}
 
-	m := NewStateMigrator(tf.Dir(), actions, nil, false)
+	m := NewStateMigrator(tf.Dir(), actions, &MigratorOption{}, false)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)


### PR DESCRIPTION
Fixes #36

Add a new flag `--out` for saving a plan file after dry-run migrations.
It almost equivalents to `terraform plan -out`, but runs after dry-run migrations. Note that the new flag is `--out`, not `-out`. This is only because the pflag library we use follows the GNU style long options.

This is intuitively simple, but after implemented, it turned out it wasn't a trivial matter. The plan file internally contains terraform configurations used by plan. The tfmigrate uses a temporary local backend configuration not to change a remote state in plan phase. This means applying the plan file affects only a local state.

We need the following steps to apply the plan:

(1) tfmigrate plan --out=foo.tfplan tfmigrate_test.hcl
(2) tfmigrate apply tfmigrate_test.hcl
(3) terraform apply foo.tfplan
(4) terraform state push -force terraform.tfstate
(5) terraform plan -detailed-exitcode
(6) rm terraform.tfstate foo.tfplan

Make sure to force push the local state to remote after `terraform apply`. The `-force` flag is required in (4) because the lineage of the state will be changed. As you know, this is unsafe operation. But I couldn't find a safe way to do this in the current technical limitations. You can confirm the final plan has no changes in (5).

There are some limitations:

1. terraform show `foo.tfplan` rejects it as a stale plan. https://github.com/hashicorp/terraform/issues/28136
2. terraform state push -force terraform.tfstate doesn't work in Terraform  >= v0.12.25 and < v0.13 https://github.com/hashicorp/terraform/issues/25761