### PR TITLE
Log terraform command before run

### DIFF
--- a/tfexec/executor.go
+++ b/tfexec/executor.go
@@ -68,8 +68,8 @@ func (e *executor) NewCommandContext(ctx context.Context, name string, args ...s
 
 // Run executes a command.
 func (e *executor) Run(cmd Command) error {
-	err := cmd.Run()
 	log.Printf("[DEBUG] [executor@%s]$ %s", e.dir, strings.Join(cmd.Args(), " "))
+	err := cmd.Run()
 	log.Printf("[TRACE] [executor@%s] cmd=%s ", e.dir, spew.Sdump(cmd))
 	if err != nil {
 		log.Printf("[DEBUG] [executor@%s] failed to run command: %s", e.dir, spew.Sdump(err))


### PR DESCRIPTION
Derived from: https://github.com/minamijoyo/tfmigrate/issues/53#issuecomment-975020063

If `teraform plan` takes a long time, it looks like `tfmigrate plan` is hanging. To help understand what's happening, log a command string before executing it.