### PR TITLE
Add list command for listing unapplied migrations

### DIFF
--- a/command/list.go
+++ b/command/list.go
@@ -1,0 +1,97 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/minamijoyo/tfmigrate/history"
+	flag "github.com/spf13/pflag"
+)
+
+// ListCommand is a command which lists migrations.
+type ListCommand struct {
+	Meta
+	status string
+}
+
+// Run runs the procedure of this command.
+func (c *ListCommand) Run(args []string) int {
+	cmdFlags := flag.NewFlagSet("list", flag.ContinueOnError)
+	cmdFlags.StringVar(&c.configFile, "config", defaultConfigFile, "A path to tfmigrate config file")
+	cmdFlags.StringVar(&c.status, "status", "unapplied", "A filter for migration status")
+
+	if err := cmdFlags.Parse(args); err != nil {
+		c.UI.Error(fmt.Sprintf("failed to parse arguments: %s", err))
+		return 1
+	}
+
+	var err error
+	if c.config, err = newConfig(c.configFile); err != nil {
+		c.UI.Error(fmt.Sprintf("failed to load config file: %s", err))
+		return 1
+	}
+	log.Printf("[DEBUG] [command] config: %#v\n", c.config)
+
+	c.Option = newOption()
+	// The option may contains sensitive values such as environment variables.
+	// So logging the option set log level to DEBUG instead of INFO.
+	log.Printf("[DEBUG] [command] option: %#v\n", c.Option)
+
+	if c.config.History == nil {
+		// non-history mode
+		c.UI.Error("no history setting")
+		return 1
+	}
+
+	// history mode
+	switch c.status {
+	case "unapplied":
+		out, err := c.listUnapplied()
+		if err != nil {
+			c.UI.Error(err.Error())
+			return 1
+		}
+		c.UI.Output(out)
+		return 0
+
+	default:
+		c.UI.Error(fmt.Sprintf("unknown filter for status: %s", c.status))
+		return 1
+	}
+}
+
+// listUnapplied lists unapplied migrations.
+func (c *ListCommand) listUnapplied() (string, error) {
+	ctx := context.Background()
+	hc, err := history.NewController(ctx, c.config.MigrationDir, c.config.History)
+	if err != nil {
+		return "", err
+	}
+
+	migrations := hc.UnappliedMigrations()
+	out := strings.Join(migrations, "\n")
+
+	return out, nil
+}
+
+// Help returns long-form help text.
+func (c *ListCommand) Help() string {
+	helpText := `
+Usage: tfmigrate list
+
+List migrations.
+
+Options:
+  --config           A path to tfmigrate config file
+  --status           A filter for migration status
+                     A valid value is only "unapplied" (default)
+`
+	return strings.TrimSpace(helpText)
+}
+
+// Synopsis returns one-line help text.
+func (c *ListCommand) Synopsis() string {
+	return "List migrations"
+}

--- a/command/list_test.go
+++ b/command/list_test.go
@@ -1,0 +1,118 @@
+package command
+
+import (
+	"context"
+	"testing"
+
+	"github.com/minamijoyo/tfmigrate/config"
+	"github.com/minamijoyo/tfmigrate/history"
+)
+
+func TestListMigrations(t *testing.T) {
+	migrations := map[string]string{
+		"20201109000001_test1.hcl": `
+migration "mock" "test1" {
+	plan_error  = false
+	apply_error = false
+}
+`,
+		"20201109000002_test2.hcl": `
+migration "mock" "test2" {
+	plan_error  = false
+	apply_error = false
+}
+`,
+		"20201109000003_test3.hcl": `
+migration "mock" "test3" {
+	plan_error  = false
+	apply_error = false
+}
+`,
+		"20201109000004_test4.hcl": `
+migration "mock" "test4" {
+	plan_error  = false
+	apply_error = false
+}
+`,
+	}
+	historyFile := `{
+    "version": 1,
+    "records": {
+        "20201109000001_test1.hcl": {
+            "type": "mock",
+            "name": "test1",
+            "applied_at": "2020-11-10T00:00:01Z"
+        },
+        "20201109000002_test2.hcl": {
+            "type": "mock",
+            "name": "test2",
+            "applied_at": "2020-11-10T00:00:02Z"
+        }
+    }
+}`
+
+	cases := []struct {
+		desc        string
+		status      string
+		migrations  map[string]string
+		historyFile string
+		want        string
+		ok          bool
+	}{
+		{
+			desc:        "all",
+			status:      "all",
+			migrations:  migrations,
+			historyFile: historyFile,
+			want: `20201109000001_test1.hcl
+20201109000002_test2.hcl
+20201109000003_test3.hcl
+20201109000004_test4.hcl`,
+			ok: true,
+		},
+		{
+			desc:        "unapplied",
+			status:      "unapplied",
+			migrations:  migrations,
+			historyFile: historyFile,
+			want: `20201109000003_test3.hcl
+20201109000004_test4.hcl`,
+			ok: true,
+		},
+		{
+			desc:        "unknown status",
+			status:      "foo",
+			migrations:  migrations,
+			historyFile: historyFile,
+			want:        "",
+			ok:          false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			migrationDir := setupMigrationDir(t, tc.migrations)
+			storage := &history.MockStorageConfig{
+				Data:       tc.historyFile,
+				WriteError: false,
+				ReadError:  false,
+			}
+			config := &config.TfmigrateConfig{
+				MigrationDir: migrationDir,
+				History: &history.Config{
+					Storage: storage,
+				},
+			}
+			got, err := listMigrations(context.Background(), config, tc.status)
+			if tc.ok && err != nil {
+				t.Fatalf("unexpected err: %s", err)
+			}
+			if !tc.ok && err == nil {
+				t.Fatal("expected to return an error, but no error")
+			}
+			if got != tc.want {
+				t.Errorf("got = %#v, want = %#v", got, tc.want)
+			}
+		})
+	}
+}

--- a/history/controller.go
+++ b/history/controller.go
@@ -127,6 +127,11 @@ func (c *Controller) Save(ctx context.Context) error {
 	return s.Write(ctx, b)
 }
 
+// Migrations returns a list of all migration file names.
+func (c *Controller) Migrations() []string {
+	return c.migrations
+}
+
 // UnappliedMigrations returns a list of migration file names which have not
 // been applied yet.
 func (c *Controller) UnappliedMigrations() []string {

--- a/main.go
+++ b/main.go
@@ -82,6 +82,11 @@ func initCommands(ui cli.Ui) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"list": func() (cli.Command, error) {
+			return &command.ListCommand{
+				Meta: meta,
+			}, nil
+		},
 	}
 
 	return commands


### PR DESCRIPTION
It would be useful if we have a command which lists unapplied migrations to integrate CI/CD easily.

```
bash-5.0# go run ../.. list --help
Usage: tfmigrate list

List migrations.

Options:
  --config           A path to tfmigrate config file
  --status           A filter for migration status
                     Valid values are as follows:
                       - all (default)
                       - unapplied
```

```
bash-5.0# go run ../.. list --status=all 2> /dev/null
mv_bar1.hcl
mv_bar2.hcl
mv_bar3.hcl
bash-5.0# go run ../.. list --status=unapplied 2> /dev/null
mv_bar2.hcl
mv_bar3.hcl
```