### PR TITLE
Add Apple Silicon (ARM 64) build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,7 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
     env:
       - CGO_ENABLED=0
 release:


### PR DESCRIPTION
Add support for Apple Silicon macs by adding an `arm64` build to `.goreleaser.yml`.