### PR TITLE
/usr/local/bin directory is not guaranteed to exist

### DIFF
--- a/tfexec/executor_test.go
+++ b/tfexec/executor_test.go
@@ -169,8 +169,8 @@ func TestExecutorDir(t *testing.T) {
 		{
 			desc: "test set dir",
 			args: []string{"pwd"},
-			dir:  "/usr/local/bin",
-			want: "/usr/local/bin\n",
+			dir:  "/bin",
+			want: "/bin\n",
 			ok:   true,
 		},
 	}

--- a/tfexec/executor_test.go
+++ b/tfexec/executor_test.go
@@ -169,8 +169,8 @@ func TestExecutorDir(t *testing.T) {
 		{
 			desc: "test set dir",
 			args: []string{"pwd"},
-			dir:  "/bin",
-			want: "/bin\n",
+			dir:  "/usr/bin",
+			want: "/usr/bin\n",
 			ok:   true,
 		},
 	}


### PR DESCRIPTION
I was running the tfmigrate tests and they failed because my machine doesn't have a `/usr/local/bin` directory. `/bin` _should_ always be there, so we can use that instead.