### PR TITLE
Support workspace for state migrator

### DIFF
--- a/tfmigrate/state_import_action_test.go
+++ b/tfmigrate/state_import_action_test.go
@@ -44,7 +44,7 @@ resource "aws_iam_user" "baz" {
 		NewStateImportAction("aws_iam_user.baz", "baz"),
 	}
 
-	m := NewStateMigrator(tf.Dir(), actions, &MigratorOption{}, false)
+	m := NewStateMigrator(tf.Dir(), "default", actions, &MigratorOption{}, false)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)

--- a/tfmigrate/state_mv_action_test.go
+++ b/tfmigrate/state_mv_action_test.go
@@ -41,7 +41,7 @@ resource "aws_security_group" "baz" {}
 		NewStateMvAction("aws_security_group.bar", "aws_security_group.bar2"),
 	}
 
-	m := NewStateMigrator(tf.Dir(), actions, &MigratorOption{}, false)
+	m := NewStateMigrator(tf.Dir(), "default", actions, &MigratorOption{}, false)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)

--- a/tfmigrate/state_rm_action_test.go
+++ b/tfmigrate/state_rm_action_test.go
@@ -40,7 +40,7 @@ resource "aws_security_group" "baz" {}
 		NewStateRmAction([]string{"aws_security_group.qux"}),
 	}
 
-	m := NewStateMigrator(tf.Dir(), actions, &MigratorOption{}, false)
+	m := NewStateMigrator(tf.Dir(), "default", actions, &MigratorOption{}, false)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)


### PR DESCRIPTION
A (single) state migration block may now specify a workspace where it is
to be applied. The state from the specified workspace is pulled for
planning and applying migrations.

Implements the single-state workspace feature request from #3.