### PR TITLE
Remove GOBIN variable from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,5 @@
 NAME := tfmigrate
 
-ifndef GOBIN
-GOBIN := $(shell echo "$${GOPATH%%:*}/bin")
-endif
-
 .DEFAULT_GOAL := build
 
 .PHONY: deps


### PR DESCRIPTION
It has no longer any effect and should be removed in #65, but I missed.