### PR TITLE
Add support for server side encryption with a KMS key id

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,7 @@ The `s3` storage has the following attributes:
 - `secret_key` (optional): AWS secret key. This can also be sourced from the `AWS_SECRET_ACCESS_KEY` environment variable, AWS shared credentials file, or AWS shared configuration file.
 - `profile` (optional): Name of AWS profile in AWS shared credentials file or AWS shared configuration file to use for credentials and/or configuration. This can also be sourced from the `AWS_PROFILE` environment variable.
 - `role_arn` (optional): Amazon Resource Name (ARN) of the IAM Role to assume.
+- `kms_key_id` (optional): Amazon Server-Side Encryption (SSE) KMS Key Id. When specified, this encryption key will be used and server-side encryption will be enabled. See the [terraform s3 backend](https://www.terraform.io/language/settings/backends/s3#kms_key_id).
 
 The following attributes are also available, but they are intended to use with `localstack` for testing.
 

--- a/history/storage_s3.go
+++ b/history/storage_s3.go
@@ -44,6 +44,8 @@ type S3StorageConfig struct {
 	// Enable path-style S3 URLs (https://<HOST>/<BUCKET>
 	// instead of https://<BUCKET>.<HOST>).
 	ForcePathStyle bool `hcl:"force_path_style,optional"`
+	// SSE KMS Key Id for optional server-side encryption enablement
+	KmsKeyID string `hcl:"kms_key_id,optional"`
 }
 
 // S3StorageConfig implements a StorageConfig.
@@ -138,6 +140,10 @@ func (s *S3Storage) Write(ctx context.Context, b []byte) error {
 		Bucket: aws.String(s.config.Bucket),
 		Key:    aws.String(s.config.Key),
 		Body:   bytes.NewReader(b),
+	}
+	if s.config.KmsKeyID != "" {
+		input.SSEKMSKeyId = &s.config.KmsKeyID
+		input.ServerSideEncryption = aws.String("aws:kms")
 	}
 
 	_, err := s.client.PutObjectWithContext(ctx, input)


### PR DESCRIPTION
This variation may be required for some S3 configurations. In my configuration, I was unable to use `tfmigrate` until I put this code in.