### PR TITLE
Use s3_use_path_style instead of s3_force_path_style

### DIFF
--- a/test-fixtures/backend_s3/config.tf
+++ b/test-fixtures/backend_s3/config.tf
@@ -26,7 +26,7 @@ provider "aws" {
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_requesting_account_id  = true
-  s3_force_path_style         = true
+  s3_use_path_style           = true
 
   // mock endpoints with localstack
   endpoints {

--- a/test-fixtures/storage_s3/config.tf
+++ b/test-fixtures/storage_s3/config.tf
@@ -26,7 +26,7 @@ provider "aws" {
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_requesting_account_id  = true
-  s3_force_path_style         = true
+  s3_use_path_style           = true
 
   // mock endpoints with localstack
   endpoints {

--- a/tfexec/terraform_test.go
+++ b/tfexec/terraform_test.go
@@ -200,7 +200,7 @@ provider "aws" {
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_requesting_account_id  = true
-  s3_force_path_style         = true
+  s3_use_path_style           = true
 
   // mock endpoints with localstack
   endpoints {

--- a/tfexec/test_helper.go
+++ b/tfexec/test_helper.go
@@ -268,7 +268,7 @@ provider "aws" {
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_requesting_account_id  = true
-  s3_force_path_style         = true
+  s3_use_path_style           = true
 
   // mock endpoints with localstack
   endpoints {


### PR DESCRIPTION
Starting from the AWS provider v4, the `s3_force_path_style` argument has been deprecated.
Use the `s3_use_path_style` argument instead.
This option is only required for localstack, which affects only test code and tutorials.
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade#s3_use_path_style