### PR TITLE
Set timeout for testacc to 20m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test: build
 
 .PHONY: testacc
 testacc: build
-	TEST_ACC=1 go test -count=1 -failfast ./...
+	TEST_ACC=1 go test -count=1 -failfast -timeout=20m ./...
 
 .PHONY: check
 check: lint test


### PR DESCRIPTION
The default timeout is 10m.
https://pkg.go.dev/cmd/go#hdr-Testing_flags

It seems that it's not enough for acceptance tests. #98
https://github.com/minamijoyo/tfmigrate/runs/7669711904?check_suite_focus=true
> panic: test timed out after 10m0s