### PR TITLE
Add a missing hyperlink into the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A Terraform state migration tool for GitOps.
          * [storage block](#storage-block)
          * [storage block (local)](#storage-block-local)
          * [storage block (s3)](#storage-block-s3)
+         * [storage block (gcs)](#storage-block-gcs)
    * [Migration file](#migration-file)
       * [migration block](#migration-block)
       * [migration block (state)](#migration-block-state)


### PR DESCRIPTION
Sorry but I forgot adding a hyperlink in the ToC of README, so here I'll propose a fix for it.

refs #103 
