### PR TITLE
Revert the deprecation of the tfmigrate plan --out=tfplan option

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,11 +318,9 @@ Options:
                            key=value format backend configuraion.
                            This option is passed to terraform init when switching backend to remote.
 
-  [Deprecated]
   --out=path               Save a plan file after dry-run migration to the given path.
-                           Note that applying the plan file only affects a local state,
-                           make sure to force push it to remote after terraform apply.
-                           This option doesn't work with Terraform 1.1+
+                           Note that the saved plan file is not applicable in Terraform 1.1+.
+                           It's intended to use only for static analysis.
 ```
 
 ```

--- a/command/plan.go
+++ b/command/plan.go
@@ -22,7 +22,7 @@ func (c *PlanCommand) Run(args []string) int {
 	cmdFlags := flag.NewFlagSet("plan", flag.ContinueOnError)
 	cmdFlags.StringVar(&c.configFile, "config", defaultConfigFile, "A path to tfmigrate config file")
 	cmdFlags.StringArrayVar(&c.backendConfig, "backend-config", nil, "A backend configuration for remote state")
-	cmdFlags.StringVar(&c.out, "out", "", "[Deprecated] Save a plan file after dry-run migration to the given path")
+	cmdFlags.StringVar(&c.out, "out", "", "Save a plan file after dry-run migration to the given path")
 
 	if err := cmdFlags.Parse(args); err != nil {
 		c.UI.Error(fmt.Sprintf("failed to parse arguments: %s", err))
@@ -42,12 +42,6 @@ func (c *PlanCommand) Run(args []string) int {
 	// The option may contains sensitive values such as environment variables.
 	// So logging the option set log level to DEBUG instead of INFO.
 	log.Printf("[DEBUG] [command] option: %#v\n", c.Option)
-
-	// The tfmigrate plan --out=tfplan option is deprecated and doesn't work with Terraform 1.1+
-	// https://github.com/minamijoyo/tfmigrate/issues/62
-	if c.Option.PlanOut != "" {
-		log.Println("[WARN] The --out option is deprecated without replacement and it will be removed in a future release")
-	}
 
 	if c.config.History == nil {
 		// non-history mode
@@ -127,11 +121,9 @@ Options:
                            key=value format backend configuraion.
                            This option is passed to terraform init when switching backend to remote.
 
-  [Deprecated]
   --out=path               Save a plan file after dry-run migration to the given path.
-                           Note that applying the plan file only affects a local state,
-                           make sure to force push it to remote after terraform apply.
-                           This option doesn't work with Terraform 1.1+
+                           Note that the saved plan file is not applicable in Terraform 1.1+.
+                           It's intended to use only for static analysis.
 `
 	return strings.TrimSpace(helpText)
 }

--- a/tfmigrate/multi_state_migrator_test.go
+++ b/tfmigrate/multi_state_migrator_test.go
@@ -326,8 +326,10 @@ func TestAccMultiStateMigratorApply(t *testing.T) {
 			}
 
 			if tc.force {
-				// The tfmigrate plan --out=tfplan option is deprecated and doesn't work with Terraform 1.1+
-				// https://github.com/minamijoyo/tfmigrate/issues/62
+				// Note that the saved plan file is not applicable in Terraform 1.1+.
+				// https://github.com/minamijoyo/tfmigrate/pull/63
+				// It's intended to use only for static analysis.
+				// https://github.com/minamijoyo/tfmigrate/issues/106
 				fromTfVersionMatched, err := tfexec.MatchTerraformVersion(ctx, fromTf, ">= 1.1.0")
 				if err != nil {
 					t.Fatalf("failed to check terraform version constraints in fromDir: %s", err)

--- a/tfmigrate/state_migrator_test.go
+++ b/tfmigrate/state_migrator_test.go
@@ -288,10 +288,10 @@ resource "aws_security_group" "baz" {}
 		t.Fatalf("expect to have changes")
 	}
 
-	// The tfmigrate plan --out=tfplan option was based on a bug prior to Terraform 1.1.
-	// Terraform v1.1 now rejects the plan as stale.
-	// The tfmigrate plan --out=tfplan option is deprecated without replacement.
-	// https://github.com/minamijoyo/tfmigrate/issues/62
+	// Note that the saved plan file is not applicable in Terraform 1.1+.
+	// https://github.com/minamijoyo/tfmigrate/pull/63
+	// It's intended to use only for static analysis.
+	// https://github.com/minamijoyo/tfmigrate/issues/106
 	tfVersionMatched, err := tfexec.MatchTerraformVersion(ctx, tf, ">= 1.1.0")
 	if err != nil {
 		t.Fatalf("failed to check terraform version constraints: %s", err)


### PR DESCRIPTION
Closes #106 

The `tfmigrate plan --out=tfplan` option was initially implemented in tfmigrate v0.2.7 and deprecated in v0.3.0 because the feature was based on a bug before Terraform v1.1. This means that the saved plan file is no longer applicable in Terraform v1.1+. https://github.com/minamijoyo/tfmigrate/pull/63

Even though, we found the plan file would still be useful for static analysis such as Conftest. https://github.com/minamijoyo/tfmigrate/issues/106
Let’s revert the deprecation and clarify it's intended to use only for static analysis.

Note that the old terraform show command before Terraform v1.1.3 rejects a plan file generated by `tfmigrate plan —out=tfplan` as stale. It works after this change. https://github.com/hashicorp/terraform/pull/30205
Use Terraform v1.1.3+ for this feature. I think this limitation is acceptable as long as it works with the latest Terraform.