### PR TITLE
Add support for Terraform v1.3

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,7 +39,8 @@ jobs:
     strategy:
       matrix:
         terraform:
-        - 1.2.0
+        - 1.3.0
+        - 1.2.9
         - 1.1.9
         - 1.0.11
         - 0.15.5

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ This brings us to a new paradigm, that is to say, Terraform state operation as C
 
 The tfmigrate invokes `terraform` command under the hood. This is because we want to support multiple terraform versions in a stable way. Currently supported terraform versions are as follows:
 
+- Terraform v1.3.x
 - Terraform v1.2.x
 - Terraform v1.1.x
 - Terraform v1.0.x


### PR DESCRIPTION
All we need is to add Terraform v1.3.0 to a test matrix.