### PR TITLE
Stop testing with old Terraform v0.13, v0.14, and v0.15

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,9 +43,6 @@ jobs:
         - 1.2.9
         - 1.1.9
         - 1.0.11
-        - 0.15.5
-        - 0.14.11
-        - 0.13.7
         - 0.12.31
     env:
       TERRAFORM_VERSION: ${{ matrix.terraform }}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Terraform state migration tool for GitOps.
 <!--ts-->
    * [Features](#features)
    * [Why?](#why)
-   * [Supported Terraform versions](#supported-terraform-versions)
+   * [Requirements](#requirements)
    * [Getting Started](#getting-started)
    * [Install](#install)
       * [Homebrew](#homebrew)
@@ -76,18 +76,11 @@ However, most Terraform refactorings require not only configuration changes, but
 To fit into the GitOps workflow, the answer is obvious. We should commit all terraform state operations to git.
 This brings us to a new paradigm, that is to say, Terraform state operation as Code!
 
-## Supported Terraform versions
+## Requirements
 
-The tfmigrate invokes `terraform` command under the hood. This is because we want to support multiple terraform versions in a stable way. Currently supported terraform versions are as follows:
+The tfmigrate invokes `terraform` command under the hood. This is because we want to support multiple terraform versions in a stable way.
 
-- Terraform v1.3.x
-- Terraform v1.2.x
-- Terraform v1.1.x
-- Terraform v1.0.x
-- Terraform v0.15.x
-- Terraform v0.14.x
-- Terraform v0.13.x
-- Terraform v0.12.x
+The minimum requirement is Terraform v0.12 or higher, but we recommend the Terraform v1.x.
 
 ## Getting Started
 


### PR DESCRIPTION
New Terraform minor versions come out every few months; running tests on all minor versions has become difficult.

In principle, we would like to support as many versions as possible, but in practice, we are unlikely to fix problems that only occur in older versions actively.

That said, there are no problems with the current implementation. We would keep the minimum requirement as Terraform v0.12 or higher, omit testing some older versions, and recommend the latest stable Terraform v1.x.

This doesn't change anything in the implementation right now, but it does change the support policy slightly.