### PR TITLE
Fix failing import acceptance test

### DIFF
--- a/tfexec/terraform_import_test.go
+++ b/tfexec/terraform_import_test.go
@@ -159,7 +159,11 @@ func TestTerraformCLIImport(t *testing.T) {
 func TestAccTerraformCLIImport(t *testing.T) {
 	SkipUnlessAcceptanceTestEnabled(t)
 
-	source := `resource "time_static" "foo" {}`
+	source := `
+resource "time_static" "foo" {
+  triggers = {}
+}
+`
 	e := SetupTestAcc(t, source)
 	terraformCLI := NewTerraformCLI(e)
 


### PR DESCRIPTION
While implementing #111, we noticed that the import acceptance test for the `tfexec` package failed.
https://github.com/minamijoyo/tfmigrate/pull/111#issuecomment-1324135641

After investigation, I found that the time provider was significantly rewritten in v0.9.0 to migrate to the new `terraform-plugin-framework`.
https://github.com/hashicorp/terraform-provider-time/pull/112

As a result, the implementation of import for the `time_static` resource now implicitly sets the `triggers` attribute to an empty map `{}` instead of `null`.

I’m not sure if this change was intentional or not, though; we can simply accept this change because there is no essential difference as long as the import success with no change.