### PR TITLE
Set TF_CLI_ARGS_apply to --parallelism=1 in sandbox

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,13 @@ services:
     environment:
       CGO_ENABLED: 0 # disable cgo for go test
       LOCALSTACK_ENDPOINT: "http://localstack:4566"
+      STORAGE_EMULATOR_HOST: "fake-gcs-server:4443"
       # Use the same filesystem to avoid a checksum mismatch error
       # or a file busy error caused by asynchronous IO.
       TF_PLUGIN_CACHE_DIR: "/tmp/plugin-cache"
-      STORAGE_EMULATOR_HOST: "fake-gcs-server:4443"
+      # From observation, although we don’t have complete confidence in the root cause,
+      # it appears that localstack sometimes misses API requests when run in parallel.
+      TF_CLI_ARGS_apply: "--parallelism=1"
     depends_on:
       - localstack
       - fake-gcs-server


### PR DESCRIPTION
The acceptance test is failing quite often these days. I was able to reproduce the problem in the sandbox environment, so I observed the state of the localstack when it failed, and found that terraform apply created only one security group when it should have created three. From observation, although we don’t have complete confidence in the root cause, it appears that localstack sometimes misses API requests when run in parallel.
Let's set the number of parallelism to 1 for terraform apply and see if it improves or not for a while.