### PR TITLE
Avoid using the AWS provider for acceptance tests

### DIFF
--- a/tfexec/terraform_test.go
+++ b/tfexec/terraform_test.go
@@ -96,15 +96,15 @@ func TestAccTerraformCLIOverrideBackendToLocal(t *testing.T) {
 
 	backend := GetTestAccBackendS3Config(t.Name())
 	source := `
-resource "aws_security_group" "foo" {}
-resource "aws_security_group" "bar" {}
+resource "null_resource" "foo" {}
+resource "null_resource" "bar" {}
 `
 	workspace := "work1"
 	terraformCLI := SetupTestAccWithApply(t, workspace, backend+source)
 
 	updatedSource := `
-resource "aws_security_group" "foo2" {}
-resource "aws_security_group" "bar" {}
+resource "null_resource" "foo2" {}
+resource "null_resource" "bar" {}
 `
 	UpdateTestAccSource(t, terraformCLI, backend+updatedSource)
 
@@ -135,7 +135,7 @@ resource "aws_security_group" "bar" {}
 		t.Fatalf("the override file does not exist: %s", err)
 	}
 
-	updatedState, _, err := terraformCLI.StateMv(context.Background(), state, nil, "aws_security_group.foo", "aws_security_group.foo2")
+	updatedState, _, err := terraformCLI.StateMv(context.Background(), state, nil, "null_resource.foo", "null_resource.foo2")
 	if err != nil {
 		t.Fatalf("failed to run terraform state mv: %s", err)
 	}
@@ -189,30 +189,10 @@ terraform {
     force_path_style            = true
   }
 }
-# https://www.terraform.io/docs/providers/aws/index.html
-# https://www.terraform.io/docs/providers/aws/guides/custom-service-endpoints.html#localstack
-provider "aws" {
-  region = "ap-northeast-1"
-
-  access_key                  = "dummy"
-  secret_key                  = "dummy"
-  skip_credentials_validation = true
-  skip_metadata_api_check     = true
-  skip_region_validation      = true
-  skip_requesting_account_id  = true
-  s3_use_path_style           = true
-
-  // mock endpoints with localstack
-  endpoints {
-    s3  = "%s"
-    ec2 = "%s"
-    iam = "%s"
-  }
-}
-`, t.Name(), endpoint, endpoint, endpoint, endpoint)
+`, t.Name(), endpoint)
 	source := `
-resource "aws_security_group" "foo" {}
-resource "aws_security_group" "bar" {}
+resource "null_resource" "foo" {}
+resource "null_resource" "bar" {}
 `
 	workspace := "work1"
 	backendConfig := []string{"bucket=tfstate-test"}
@@ -251,8 +231,8 @@ resource "aws_security_group" "bar" {}
 	})
 
 	updatedSource := `
-resource "aws_security_group" "foo2" {}
-resource "aws_security_group" "bar" {}
+resource "null_resource" "foo2" {}
+resource "null_resource" "bar" {}
 `
 	UpdateTestAccSource(t, terraformCLI, backend+updatedSource)
 
@@ -283,7 +263,7 @@ resource "aws_security_group" "bar" {}
 		t.Fatalf("the override file does not exist: %s", err)
 	}
 
-	updatedState, _, err := terraformCLI.StateMv(context.Background(), state, nil, "aws_security_group.foo", "aws_security_group.foo2")
+	updatedState, _, err := terraformCLI.StateMv(context.Background(), state, nil, "null_resource.foo", "null_resource.foo2")
 	if err != nil {
 		t.Fatalf("failed to run terraform state mv: %s", err)
 	}

--- a/tfexec/test_helper.go
+++ b/tfexec/test_helper.go
@@ -256,27 +256,7 @@ terraform {
     force_path_style            = true
   }
 }
-# https://www.terraform.io/docs/providers/aws/index.html
-# https://www.terraform.io/docs/providers/aws/guides/custom-service-endpoints.html#localstack
-provider "aws" {
-  region = "ap-northeast-1"
-
-  access_key                  = "dummy"
-  secret_key                  = "dummy"
-  skip_credentials_validation = true
-  skip_metadata_api_check     = true
-  skip_region_validation      = true
-  skip_requesting_account_id  = true
-  s3_use_path_style           = true
-
-  // mock endpoints with localstack
-  endpoints {
-    s3  = "%s"
-    ec2 = "%s"
-    iam = "%s"
-  }
-}
-`, dir, endpoint, endpoint, endpoint, endpoint)
+`, dir, endpoint)
 	return backendConfig
 }
 

--- a/tfmigrate/multi_state_migrator_test.go
+++ b/tfmigrate/multi_state_migrator_test.go
@@ -131,35 +131,35 @@ func TestAccMultiStateMigratorApply(t *testing.T) {
 			desc:          "multi-state migration between default workspaces",
 			fromWorkspace: "default",
 			fromSource: `
-			resource "aws_security_group" "foo" {}
-			resource "aws_security_group" "bar" {}
-			resource "aws_security_group" "baz" {}
+			resource "null_resource" "foo" {}
+			resource "null_resource" "bar" {}
+			resource "null_resource" "baz" {}
 			`,
 			fromUpdatedSource: `
-			resource "aws_security_group" "baz" {}
+			resource "null_resource" "baz" {}
 			`,
 			fromUpdatedState: []string{
-				"aws_security_group.baz",
+				"null_resource.baz",
 			},
 			fromStateExpectChange: false,
 			toWorkspace:           "default",
 			toSource: `
-			resource "aws_security_group" "qux" {}
+			resource "null_resource" "qux" {}
 			`,
 			toUpdatedSource: `
-			resource "aws_security_group" "foo" {}
-			resource "aws_security_group" "bar2" {}
-			resource "aws_security_group" "qux" {}
+			resource "null_resource" "foo" {}
+			resource "null_resource" "bar2" {}
+			resource "null_resource" "qux" {}
 			`,
 			toUpdatedState: []string{
-				"aws_security_group.foo",
-				"aws_security_group.bar2",
-				"aws_security_group.qux",
+				"null_resource.foo",
+				"null_resource.bar2",
+				"null_resource.qux",
 			},
 			toStateExpectChange: false,
 			actions: []string{
-				"mv aws_security_group.foo aws_security_group.foo",
-				"mv aws_security_group.bar aws_security_group.bar2",
+				"mv null_resource.foo null_resource.foo",
+				"mv null_resource.bar null_resource.bar2",
 			},
 			force: false,
 		},
@@ -167,36 +167,36 @@ func TestAccMultiStateMigratorApply(t *testing.T) {
 			desc:          "multi-state migration between default workspaces with force == true",
 			fromWorkspace: "default",
 			fromSource: `
-			resource "aws_security_group" "foo" {}
-			resource "aws_security_group" "bar" {}
-			resource "aws_security_group" "baz" {}
+			resource "null_resource" "foo" {}
+			resource "null_resource" "bar" {}
+			resource "null_resource" "baz" {}
 			`,
 			fromUpdatedSource: `
-			resource "aws_security_group" "baz" {}
+			resource "null_resource" "baz" {}
 			`,
 			fromUpdatedState: []string{
-				"aws_security_group.baz",
+				"null_resource.baz",
 			},
 			fromStateExpectChange: false,
 			toWorkspace:           "default",
 			toSource: `
-			resource "aws_security_group" "qux" {}
+			resource "null_resource" "qux" {}
 			`,
 			toUpdatedSource: `
-			resource "aws_security_group" "foo" {}
-			resource "aws_security_group" "bar2" {}
-			resource "aws_security_group" "qux" {}
-			resource "aws_security_group" "qux2" {}
+			resource "null_resource" "foo" {}
+			resource "null_resource" "bar2" {}
+			resource "null_resource" "qux" {}
+			resource "null_resource" "qux2" {}
 			`,
 			toUpdatedState: []string{
-				"aws_security_group.foo",
-				"aws_security_group.bar2",
-				"aws_security_group.qux",
+				"null_resource.foo",
+				"null_resource.bar2",
+				"null_resource.qux",
 			},
 			toStateExpectChange: true,
 			actions: []string{
-				"mv aws_security_group.foo aws_security_group.foo",
-				"mv aws_security_group.bar aws_security_group.bar2",
+				"mv null_resource.foo null_resource.foo",
+				"mv null_resource.bar null_resource.bar2",
 			},
 			force: true,
 		},
@@ -204,35 +204,35 @@ func TestAccMultiStateMigratorApply(t *testing.T) {
 			desc:          "multi-state migration between user-defined workspaces",
 			fromWorkspace: "work1",
 			fromSource: `
-			resource "aws_security_group" "foo" {}
-			resource "aws_security_group" "bar" {}
-			resource "aws_security_group" "baz" {}
+			resource "null_resource" "foo" {}
+			resource "null_resource" "bar" {}
+			resource "null_resource" "baz" {}
 			`,
 			fromUpdatedSource: `
-			resource "aws_security_group" "baz" {}
+			resource "null_resource" "baz" {}
 			`,
 			fromUpdatedState: []string{
-				"aws_security_group.baz",
+				"null_resource.baz",
 			},
 			fromStateExpectChange: false,
 			toWorkspace:           "work2",
 			toSource: `
-			resource "aws_security_group" "qux" {}
+			resource "null_resource" "qux" {}
 			`,
 			toUpdatedSource: `
-			resource "aws_security_group" "foo" {}
-			resource "aws_security_group" "bar2" {}
-			resource "aws_security_group" "qux" {}
+			resource "null_resource" "foo" {}
+			resource "null_resource" "bar2" {}
+			resource "null_resource" "qux" {}
 			`,
 			toUpdatedState: []string{
-				"aws_security_group.foo",
-				"aws_security_group.bar2",
-				"aws_security_group.qux",
+				"null_resource.foo",
+				"null_resource.bar2",
+				"null_resource.qux",
 			},
 			toStateExpectChange: false,
 			actions: []string{
-				"mv aws_security_group.foo aws_security_group.foo",
-				"mv aws_security_group.bar aws_security_group.bar2",
+				"mv null_resource.foo null_resource.foo",
+				"mv null_resource.bar null_resource.bar2",
 			},
 			force: false,
 		},

--- a/tfmigrate/state_import_action_test.go
+++ b/tfmigrate/state_import_action_test.go
@@ -13,20 +13,20 @@ func TestAccStateImportAction(t *testing.T) {
 	backend := tfexec.GetTestAccBackendS3Config(t.Name())
 
 	source := `
-resource "aws_iam_user" "foo" {
-	name = "foo"
+resource "time_static" "foo" {
+  triggers = {}
 }
-resource "aws_iam_user" "bar" {
-	name = "bar"
+resource "time_static" "bar" {
+  triggers = {}
 }
-resource "aws_iam_user" "baz" {
-	name = "baz"
+resource "time_static" "baz" {
+  triggers = {}
 }
 `
 	tf := tfexec.SetupTestAccWithApply(t, "default", backend+source)
 	ctx := context.Background()
 
-	_, err := tf.StateRm(ctx, nil, []string{"aws_iam_user.foo", "aws_iam_user.baz"})
+	_, err := tf.StateRm(ctx, nil, []string{"time_static.foo", "time_static.baz"})
 	if err != nil {
 		t.Fatalf("failed to run terraform state rm: %s", err)
 	}
@@ -40,8 +40,8 @@ resource "aws_iam_user" "baz" {
 	}
 
 	actions := []StateAction{
-		NewStateImportAction("aws_iam_user.foo", "foo"),
-		NewStateImportAction("aws_iam_user.baz", "baz"),
+		NewStateImportAction("time_static.foo", "2006-01-02T15:04:05Z"),
+		NewStateImportAction("time_static.baz", "2006-01-02T15:04:05Z"),
 	}
 
 	m := NewStateMigrator(tf.Dir(), "default", actions, &MigratorOption{}, false)

--- a/tfmigrate/state_mv_action_test.go
+++ b/tfmigrate/state_mv_action_test.go
@@ -13,17 +13,17 @@ func TestAccStateMvAction(t *testing.T) {
 	backend := tfexec.GetTestAccBackendS3Config(t.Name())
 
 	source := `
-resource "aws_security_group" "foo" {}
-resource "aws_security_group" "bar" {}
-resource "aws_security_group" "baz" {}
+resource "null_resource" "foo" {}
+resource "null_resource" "bar" {}
+resource "null_resource" "baz" {}
 `
 	tf := tfexec.SetupTestAccWithApply(t, "default", backend+source)
 	ctx := context.Background()
 
 	updatedSource := `
-resource "aws_security_group" "foo2" {}
-resource "aws_security_group" "bar2" {}
-resource "aws_security_group" "baz" {}
+resource "null_resource" "foo2" {}
+resource "null_resource" "bar2" {}
+resource "null_resource" "baz" {}
 `
 
 	tfexec.UpdateTestAccSource(t, tf, backend+updatedSource)
@@ -37,8 +37,8 @@ resource "aws_security_group" "baz" {}
 	}
 
 	actions := []StateAction{
-		NewStateMvAction("aws_security_group.foo", "aws_security_group.foo2"),
-		NewStateMvAction("aws_security_group.bar", "aws_security_group.bar2"),
+		NewStateMvAction("null_resource.foo", "null_resource.foo2"),
+		NewStateMvAction("null_resource.bar", "null_resource.bar2"),
 	}
 
 	m := NewStateMigrator(tf.Dir(), "default", actions, &MigratorOption{}, false)

--- a/tfmigrate/state_rm_action_test.go
+++ b/tfmigrate/state_rm_action_test.go
@@ -13,16 +13,16 @@ func TestAccStateRmAction(t *testing.T) {
 	backend := tfexec.GetTestAccBackendS3Config(t.Name())
 
 	source := `
-resource "aws_security_group" "foo" {}
-resource "aws_security_group" "bar" {}
-resource "aws_security_group" "baz" {}
-resource "aws_security_group" "qux" {}
+resource "null_resource" "foo" {}
+resource "null_resource" "bar" {}
+resource "null_resource" "baz" {}
+resource "null_resource" "qux" {}
 `
 	tf := tfexec.SetupTestAccWithApply(t, "default", backend+source)
 	ctx := context.Background()
 
 	updatedSource := `
-resource "aws_security_group" "baz" {}
+resource "null_resource" "baz" {}
 `
 
 	tfexec.UpdateTestAccSource(t, tf, backend+updatedSource)
@@ -36,8 +36,8 @@ resource "aws_security_group" "baz" {}
 	}
 
 	actions := []StateAction{
-		NewStateRmAction([]string{"aws_security_group.foo", "aws_security_group.bar"}),
-		NewStateRmAction([]string{"aws_security_group.qux"}),
+		NewStateRmAction([]string{"null_resource.foo", "null_resource.bar"}),
+		NewStateRmAction([]string{"null_resource.qux"}),
 	}
 
 	m := NewStateMigrator(tf.Dir(), "default", actions, &MigratorOption{}, false)

--- a/tfmigrate/state_xmv_action_test.go
+++ b/tfmigrate/state_xmv_action_test.go
@@ -15,15 +15,15 @@ func TestAccStateMvActionWildcardRenameSecurityGroupResourceNamesFromDocs(t *tes
 	backend := tfexec.GetTestAccBackendS3Config(t.Name())
 
 	source := `
-resource "aws_security_group" "foo" {}
-resource "aws_security_group" "bar" {}
+resource "null_resource" "foo" {}
+resource "null_resource" "bar" {}
 `
 	tf := tfexec.SetupTestAccWithApply(t, "default", backend+source)
 	ctx := context.Background()
 
 	updatedSource := `
-resource "aws_security_group" "foo2" {}
-resource "aws_security_group" "bar2" {}
+resource "null_resource" "foo2" {}
+resource "null_resource" "bar2" {}
 `
 	tfexec.UpdateTestAccSource(t, tf, backend+updatedSource)
 
@@ -36,7 +36,7 @@ resource "aws_security_group" "bar2" {}
 	}
 
 	actions := []StateAction{
-		NewStateXMvAction("aws_security_group.*", "aws_security_group.${1}2"),
+		NewStateXMvAction("null_resource.*", "null_resource.${1}2"),
 	}
 
 	m := NewStateMigrator(tf.Dir(), "default", actions, &MigratorOption{}, false)


### PR DESCRIPTION
I suspect localstack is the reason why acceptance tests are slow and unstable. It's hard to completely eliminate localstack due to the s3 backend dependency, but we can avoid using the AWS provider whenever possible.