### PR TITLE
Disable fail-fast for matrix tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
+      fail-fast: false
       matrix:
         terraform:
         - 1.3.6


### PR DESCRIPTION
Recently, acceptance tests has been unstable.
It's better to run them all anyway.