### PR TITLE
Download the providers and generate a cache once before testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,12 @@ lint:
 test: build
 	go test ./...
 
+.PHONY: generate-plugin-cache
+generate-plugin-cache:
+	scripts/testacc/generate_plugin_cache.sh
+
 .PHONY: testacc
-testacc: build
+testacc: build generate-plugin-cache
 	TEST_ACC=1 go test -count=1 -failfast -timeout=20m ./...
 
 .PHONY: check

--- a/scripts/testacc/generate_plugin_cache.sh
+++ b/scripts/testacc/generate_plugin_cache.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# When using TF_PLUGIN_CACHE_DIR, terraform init is not concurrency safe.
+# https://github.com/hashicorp/terraform/issues/25849
+# Download the providers and generate a cache once before testing.
+mkdir -p "$TF_PLUGIN_CACHE_DIR"
+
+WORK_DIR="./tmp/generate_plugin_cache"
+mkdir -p "$WORK_DIR"
+pushd "$WORK_DIR"
+
+# Note that it must be written in Terraform v0.12 compatible.
+# In other words, you cannot specify a namespace.
+cat << EOF > main.tf
+terraform {
+  required_providers {
+    null = "3.2.1"
+    time = "0.9.1"
+  }
+}
+EOF
+
+terraform init -input=false -no-color
+
+popd
+rm -rf "$WORK_DIR"


### PR DESCRIPTION
When using TF_PLUGIN_CACHE_DIR, terraform init is not concurrency safe, and acceptance tests frequently fail with checksum mismatch errors.
https://github.com/hashicorp/terraform/issues/25849
To avoid this problem, download the providers and generate a cache once before testing.
I wish we could use the terraform providers mirror command, but it's only available in v0.13 or later.
We use a simple terraform init to make it work with Terraform v0.12.