### PR TITLE
Restructure acceptance tests

### DIFF
--- a/tfexec/terraform_import_test.go
+++ b/tfexec/terraform_import_test.go
@@ -160,9 +160,7 @@ func TestAccTerraformCLIImport(t *testing.T) {
 	SkipUnlessAcceptanceTestEnabled(t)
 
 	source := `
-resource "time_static" "foo" {
-  triggers = {}
-}
+resource "time_static" "foo" { triggers = {} }
 `
 	e := SetupTestAcc(t, source)
 	terraformCLI := NewTerraformCLI(e)

--- a/tfmigrate/state_import_action_test.go
+++ b/tfmigrate/state_import_action_test.go
@@ -23,7 +23,9 @@ resource "time_static" "baz" {
   triggers = {}
 }
 `
-	tf := tfexec.SetupTestAccWithApply(t, "default", backend+source)
+
+	workspace := "default"
+	tf := tfexec.SetupTestAccWithApply(t, workspace, backend+source)
 	ctx := context.Background()
 
 	_, err := tf.StateRm(ctx, nil, []string{"time_static.foo", "time_static.baz"})
@@ -44,7 +46,7 @@ resource "time_static" "baz" {
 		NewStateImportAction("time_static.baz", "2006-01-02T15:04:05Z"),
 	}
 
-	m := NewStateMigrator(tf.Dir(), "default", actions, &MigratorOption{}, false)
+	m := NewStateMigrator(tf.Dir(), workspace, actions, &MigratorOption{}, false)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)

--- a/tfmigrate/state_import_action_test.go
+++ b/tfmigrate/state_import_action_test.go
@@ -13,15 +13,9 @@ func TestAccStateImportAction(t *testing.T) {
 	backend := tfexec.GetTestAccBackendS3Config(t.Name())
 
 	source := `
-resource "time_static" "foo" {
-  triggers = {}
-}
-resource "time_static" "bar" {
-  triggers = {}
-}
-resource "time_static" "baz" {
-  triggers = {}
-}
+resource "time_static" "foo" { triggers = {} }
+resource "time_static" "bar" { triggers = {} }
+resource "time_static" "baz" { triggers = {} }
 `
 
 	workspace := "default"

--- a/tfmigrate/state_migrator_test.go
+++ b/tfmigrate/state_migrator_test.go
@@ -163,7 +163,8 @@ resource "time_static" "qux" { triggers = {} }
 		NewStateImportAction("time_static.qux", "2006-01-02T15:04:05Z"),
 	}
 
-	m := NewStateMigrator(tf.Dir(), workspace, actions, &MigratorOption{}, false)
+	force := false
+	m := NewStateMigrator(tf.Dir(), workspace, actions, &MigratorOption{}, force)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)
@@ -232,7 +233,8 @@ resource "null_resource" "bar" {}
 		NewStateMvAction("null_resource.foo", "null_resource.foo2"),
 	}
 
-	m := NewStateMigrator(tf.Dir(), workspace, actions, &MigratorOption{}, false)
+	force := false
+	m := NewStateMigrator(tf.Dir(), workspace, actions, &MigratorOption{}, force)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)
@@ -303,8 +305,8 @@ resource "null_resource" "baz" {}
 
 	o := &MigratorOption{}
 	o.PlanOut = "foo.tfplan"
-
-	m := NewStateMigrator(tf.Dir(), workspace, actions, o, true)
+	force := true
+	m := NewStateMigrator(tf.Dir(), workspace, actions, o, force)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)

--- a/tfmigrate/state_migrator_test.go
+++ b/tfmigrate/state_migrator_test.go
@@ -120,106 +120,86 @@ func TestStateMigratorConfigNewMigrator(t *testing.T) {
 	}
 }
 
-func TestAccStateMigratorApply(t *testing.T) {
+func TestAccStateMigratorApplySimple(t *testing.T) {
 	tfexec.SkipUnlessAcceptanceTestEnabled(t)
 
-	cases := []struct {
-		desc      string
-		workspace string
-	}{
-		{
-			desc:      "default workspace",
-			workspace: "default",
-		},
-		{
-			desc:      "non-default workspace",
-			workspace: "workspace1",
-		},
-	}
+	backend := tfexec.GetTestAccBackendS3Config(t.Name())
 
-	for _, tc := range cases {
-		t.Run(tc.desc, func(t *testing.T) {
-			backend := tfexec.GetTestAccBackendS3Config(t.Name())
-
-			source := `
+	source := `
 resource "null_resource" "foo" {}
 resource "null_resource" "bar" {}
 resource "null_resource" "baz" {}
-resource "time_static" "qux" {
-  triggers = {}
-}
+resource "time_static" "qux" { triggers = {} }
 `
-			tf := tfexec.SetupTestAccWithApply(t, tc.workspace, backend+source)
-			ctx := context.Background()
 
-			updatedSource := `
+	workspace := "default"
+	tf := tfexec.SetupTestAccWithApply(t, workspace, backend+source)
+	ctx := context.Background()
+
+	updatedSource := `
 resource "null_resource" "foo2" {}
 resource "null_resource" "baz" {}
-resource "time_static" "qux" {
-  triggers = {}
-}
+resource "time_static" "qux" { triggers = {} }
 `
 
-			tfexec.UpdateTestAccSource(t, tf, backend+updatedSource)
+	tfexec.UpdateTestAccSource(t, tf, backend+updatedSource)
 
-			_, err := tf.StateRm(ctx, nil, []string{"time_static.qux"})
-			if err != nil {
-				t.Fatalf("failed to run terraform state rm: %s", err)
-			}
+	_, err := tf.StateRm(ctx, nil, []string{"time_static.qux"})
+	if err != nil {
+		t.Fatalf("failed to run terraform state rm: %s", err)
+	}
 
-			changed, err := tf.PlanHasChange(ctx, nil)
-			if err != nil {
-				t.Fatalf("failed to run PlanHasChange: %s", err)
-			}
-			if !changed {
-				t.Fatalf("expect to have changes")
-			}
+	changed, err := tf.PlanHasChange(ctx, nil)
+	if err != nil {
+		t.Fatalf("failed to run PlanHasChange: %s", err)
+	}
+	if !changed {
+		t.Fatalf("expect to have changes")
+	}
 
-			actions := []StateAction{
-				NewStateMvAction("null_resource.foo", "null_resource.foo2"),
-				NewStateRmAction([]string{"null_resource.bar"}),
-				NewStateImportAction("time_static.qux", "2006-01-02T15:04:05Z"),
-			}
+	actions := []StateAction{
+		NewStateMvAction("null_resource.foo", "null_resource.foo2"),
+		NewStateRmAction([]string{"null_resource.bar"}),
+		NewStateImportAction("time_static.qux", "2006-01-02T15:04:05Z"),
+	}
 
-			m := NewStateMigrator(tf.Dir(), tc.workspace, actions, &MigratorOption{}, false)
-			err = m.Plan(ctx)
-			if err != nil {
-				t.Fatalf("failed to run migrator plan: %s", err)
-			}
+	m := NewStateMigrator(tf.Dir(), workspace, actions, &MigratorOption{}, false)
+	err = m.Plan(ctx)
+	if err != nil {
+		t.Fatalf("failed to run migrator plan: %s", err)
+	}
 
-			err = m.Apply(ctx)
-			if err != nil {
-				t.Fatalf("failed to run migrator apply: %s", err)
-			}
+	err = m.Apply(ctx)
+	if err != nil {
+		t.Fatalf("failed to run migrator apply: %s", err)
+	}
 
-			got, err := tf.StateList(ctx, nil, nil)
-			if err != nil {
-				t.Fatalf("failed to run terraform state list: %s", err)
-			}
+	got, err := tf.StateList(ctx, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to run terraform state list: %s", err)
+	}
 
-			want := []string{
-				"null_resource.foo2",
-				"null_resource.baz",
-				"time_static.qux",
-			}
-			sort.Strings(got)
-			sort.Strings(want)
-			if !reflect.DeepEqual(got, want) {
-				t.Errorf("got state: %v, want state: %v", got, want)
-			}
+	want := []string{
+		"null_resource.foo2",
+		"null_resource.baz",
+		"time_static.qux",
+	}
+	sort.Strings(got)
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got state: %v, want state: %v", got, want)
+	}
 
-			changed, err = tf.PlanHasChange(ctx, nil)
-			if err != nil {
-				t.Fatalf("failed to run PlanHasChange: %s", err)
-			}
-			if changed {
-				t.Fatalf("expect not to have changes")
-			}
-		})
+	changed, err = tf.PlanHasChange(ctx, nil)
+	if err != nil {
+		t.Fatalf("failed to run PlanHasChange: %s", err)
+	}
+	if changed {
+		t.Fatalf("expect not to have changes")
 	}
 }
 
-func TestAccStateMigratorApplyForce(t *testing.T) {
+func TestAccStateMigratorApplyWithWorkspace(t *testing.T) {
 	tfexec.SkipUnlessAcceptanceTestEnabled(t)
 
 	backend := tfexec.GetTestAccBackendS3Config(t.Name())
@@ -228,7 +208,77 @@ func TestAccStateMigratorApplyForce(t *testing.T) {
 resource "null_resource" "foo" {}
 resource "null_resource" "bar" {}
 `
-	tf := tfexec.SetupTestAccWithApply(t, "default", backend+source)
+
+	workspace := "workspace1"
+	tf := tfexec.SetupTestAccWithApply(t, workspace, backend+source)
+	ctx := context.Background()
+
+	updatedSource := `
+resource "null_resource" "foo2" {}
+resource "null_resource" "bar" {}
+`
+
+	tfexec.UpdateTestAccSource(t, tf, backend+updatedSource)
+
+	changed, err := tf.PlanHasChange(ctx, nil)
+	if err != nil {
+		t.Fatalf("failed to run PlanHasChange: %s", err)
+	}
+	if !changed {
+		t.Fatalf("expect to have changes")
+	}
+
+	actions := []StateAction{
+		NewStateMvAction("null_resource.foo", "null_resource.foo2"),
+	}
+
+	m := NewStateMigrator(tf.Dir(), workspace, actions, &MigratorOption{}, false)
+	err = m.Plan(ctx)
+	if err != nil {
+		t.Fatalf("failed to run migrator plan: %s", err)
+	}
+
+	err = m.Apply(ctx)
+	if err != nil {
+		t.Fatalf("failed to run migrator apply: %s", err)
+	}
+
+	got, err := tf.StateList(ctx, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to run terraform state list: %s", err)
+	}
+
+	want := []string{
+		"null_resource.foo2",
+		"null_resource.bar",
+	}
+	sort.Strings(got)
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got state: %v, want state: %v", got, want)
+	}
+
+	changed, err = tf.PlanHasChange(ctx, nil)
+	if err != nil {
+		t.Fatalf("failed to run PlanHasChange: %s", err)
+	}
+	if changed {
+		t.Fatalf("expect not to have changes")
+	}
+}
+
+func TestAccStateMigratorApplyWithForce(t *testing.T) {
+	tfexec.SkipUnlessAcceptanceTestEnabled(t)
+
+	backend := tfexec.GetTestAccBackendS3Config(t.Name())
+
+	source := `
+resource "null_resource" "foo" {}
+resource "null_resource" "bar" {}
+`
+
+	workspace := "default"
+	tf := tfexec.SetupTestAccWithApply(t, workspace, backend+source)
 	ctx := context.Background()
 
 	updatedSource := `
@@ -254,7 +304,7 @@ resource "null_resource" "baz" {}
 	o := &MigratorOption{}
 	o.PlanOut = "foo.tfplan"
 
-	m := NewStateMigrator(tf.Dir(), "default", actions, o, true)
+	m := NewStateMigrator(tf.Dir(), workspace, actions, o, true)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)

--- a/tfmigrate/state_mv_action_test.go
+++ b/tfmigrate/state_mv_action_test.go
@@ -17,7 +17,9 @@ resource "null_resource" "foo" {}
 resource "null_resource" "bar" {}
 resource "null_resource" "baz" {}
 `
-	tf := tfexec.SetupTestAccWithApply(t, "default", backend+source)
+
+	workspace := "default"
+	tf := tfexec.SetupTestAccWithApply(t, workspace, backend+source)
 	ctx := context.Background()
 
 	updatedSource := `
@@ -41,7 +43,7 @@ resource "null_resource" "baz" {}
 		NewStateMvAction("null_resource.bar", "null_resource.bar2"),
 	}
 
-	m := NewStateMigrator(tf.Dir(), "default", actions, &MigratorOption{}, false)
+	m := NewStateMigrator(tf.Dir(), workspace, actions, &MigratorOption{}, false)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)

--- a/tfmigrate/state_rm_action_test.go
+++ b/tfmigrate/state_rm_action_test.go
@@ -18,7 +18,9 @@ resource "null_resource" "bar" {}
 resource "null_resource" "baz" {}
 resource "null_resource" "qux" {}
 `
-	tf := tfexec.SetupTestAccWithApply(t, "default", backend+source)
+
+	workspace := "default"
+	tf := tfexec.SetupTestAccWithApply(t, workspace, backend+source)
 	ctx := context.Background()
 
 	updatedSource := `
@@ -40,7 +42,7 @@ resource "null_resource" "baz" {}
 		NewStateRmAction([]string{"null_resource.qux"}),
 	}
 
-	m := NewStateMigrator(tf.Dir(), "default", actions, &MigratorOption{}, false)
+	m := NewStateMigrator(tf.Dir(), workspace, actions, &MigratorOption{}, false)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)

--- a/tfmigrate/state_xmv_action_test.go
+++ b/tfmigrate/state_xmv_action_test.go
@@ -18,7 +18,9 @@ func TestAccStateMvActionWildcardRenameSecurityGroupResourceNamesFromDocs(t *tes
 resource "null_resource" "foo" {}
 resource "null_resource" "bar" {}
 `
-	tf := tfexec.SetupTestAccWithApply(t, "default", backend+source)
+
+	workspace := "default"
+	tf := tfexec.SetupTestAccWithApply(t, workspace, backend+source)
 	ctx := context.Background()
 
 	updatedSource := `
@@ -39,7 +41,7 @@ resource "null_resource" "bar2" {}
 		NewStateXMvAction("null_resource.*", "null_resource.${1}2"),
 	}
 
-	m := NewStateMigrator(tf.Dir(), "default", actions, &MigratorOption{}, false)
+	m := NewStateMigrator(tf.Dir(), workspace, actions, &MigratorOption{}, false)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)


### PR DESCRIPTION
As acceptance tests were becoming overly parameterized and hard to read, let's restructure them up by scenarios. Despite the fact that there are many superficial test code changes, I believe the points of verification have not changed.