### PR TITLE
Add support for Terraform v1.4

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,10 +40,9 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-        - 1.3.8
+        - 1.4.0
+        - 1.3.9
         - 1.2.9
-        - 1.1.9
-        - 1.0.11
         - 0.12.31
     env:
       TERRAFORM_VERSION: ${{ matrix.terraform }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       # Use the same filesystem to avoid a checksum mismatch error
       # or a file busy error caused by asynchronous IO.
       TF_PLUGIN_CACHE_DIR: "/tmp/plugin-cache"
+      TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE: "true"
       # From observation, although we don’t have complete confidence in the root cause,
       # it appears that localstack sometimes misses API requests when run in parallel.
       TF_CLI_ARGS_apply: "--parallelism=1"

--- a/scripts/testacc/generate_plugin_cache.sh
+++ b/scripts/testacc/generate_plugin_cache.sh
@@ -22,6 +22,27 @@ terraform {
 }
 EOF
 
+# Starting with Terraform v1.4, the global plugin cache is ignored on the first
+# terraform init. This makes caching in CI meaningless. To utilize the cache,
+# we use a local filesystem mirror. Strictly speaking, the mirror is only
+# available in Terraform v0.13+, but it is hard to compare versions in bash,
+# so we use the mirror unless v0.x.
+# https://developer.hashicorp.com/terraform/cli/config/config-file#implied-local-mirror-directories
+if terraform -v | grep 'Terraform v0\.'; then
+  echo "skip creating an implied local mirror"
+else
+  FS_MIRROR="/tmp/plugin-mirror"
+  terraform providers mirror "${FS_MIRROR}"
+
+  cat << EOF > "$HOME/.terraformrc"
+provider_installation {
+  filesystem_mirror {
+    path    = "/tmp/plugin-mirror"
+  }
+}
+EOF
+fi
+
 terraform init -input=false -no-color
 
 popd


### PR DESCRIPTION
There are no changes in implementation, but some adjustments have been made to the test settings:

(1) Add terraform 1.4.0 to the test matrix
(2) Use a local filesystem mirror on CI
Starting with Terraform v1.4, the global plugin cache is ignored on the first terraform init. This makes caching in CI meaningless: https://github.com/hashicorp/terraform/pull/32494

To utilize the cache, we use a local filesystem mirror. Strictly speaking, the mirror is only available in Terraform v0.13+, but it is hard to compare versions in bash, so we use the mirror unless v0.x.
https://developer.hashicorp.com/terraform/cli/config/config-file#implied-local-mirror-directories

(3) Export TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE=true in CI
Starting from Terraform v1.4, launching terraform providers in the acceptance test has been failing more frequently with a text file busy error.

```
--- FAIL: TestAccMultiStateMigratorApplySimple (1.07s)
    multi_state_migrator_test.go:123: failed to run terraform init: failed to run command (exited 1): terraform init -input=false -no-color
        stdout:

        Initializing the backend...

        Successfully configured the backend "s3"! Terraform will automatically
        use this backend unless the backend configuration changes.

        Initializing provider plugins...
        - Finding latest version of hashicorp/null...
        - Installing hashicorp/null v3.2.1...

        stderr:

        Error: Failed to install provider

        Error while installing hashicorp/null v3.2.1: open
        /tmp/plugin-cache/registry.terraform.io/hashicorp/null/3.2.1/linux_amd64/terraform-provider-null_v3.2.1_x5:
        text file busy
```

After some investigation, I found Go's `os/exec.Cmd.Run()` does not wait for the grandchild process to complete; from the point of view of tfmigrate, the terraform command is the child process, and the provider is the grandchild process.
https://github.com/golang/go/issues/23019

If I understand correctly, this is not a Terraform issue and theoretically should occur in versions older than v1.4; the changes in v1.4 may have broken the balance of execution timing and made the test very flaky. I experimented with inserting some sleep but could not get the test to stabilize correctly. After trying various things, I found that the test became stable by enabling the `TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE` flag was introduced in v1.4. This is an escape hatch to revert to the v1.3 equivalent of the global cache behavior change in v1.4.
https://github.com/hashicorp/terraform/pull/32726

This behavior change has already been addressed in the previous commit using a local file system mirror, so activating this flag does not seem to make any sense. Even though I have no other reasonable solutions now, please let me know if anyone finds a better solution.