### PR TITLE
add global force option

### DIFF
--- a/config/tfmigrate.go
+++ b/config/tfmigrate.go
@@ -25,6 +25,8 @@ type TfmigrateBlock struct {
 	IsBackendTerraformCloud bool `hcl:"is_backend_terraform_cloud,optional"`
 	// History is a block for migration history management.
 	History *HistoryBlock `hcl:"history,block"`
+    //  GlobalForce is a boolean representing a force on all migration files
+	GlobalForce bool
 }
 
 // TfmigrateConfig is a config for top-level CLI settings.
@@ -39,6 +41,8 @@ type TfmigrateConfig struct {
 	IsBackendTerraformCloud bool
 	// History is a config for migration history management.
 	History *history.Config
+    //  GlobalForce is a boolean representing a force on all migration files
+	GlobalForce bool
 }
 
 // LoadConfigurationFile is a helper function which reads and parses a given configuration file.
@@ -79,6 +83,10 @@ func ParseConfigurationFile(filename string, source []byte) (*TfmigrateConfig, e
 		config.History = history
 	}
 
+    if f.Tfmigrate.GlobalForce != nil {
+        config.GlobalForce = f.Tfmigrate.GlobalForce
+    }
+
 	return config, nil
 }
 
@@ -87,5 +95,6 @@ func NewDefaultConfig() *TfmigrateConfig {
 	return &TfmigrateConfig{
 		MigrationDir:            ".",
 		IsBackendTerraformCloud: false,
+		GlobalForce: false,
 	}
 }

--- a/tfmigrate/multi_state_migrator.go
+++ b/tfmigrate/multi_state_migrator.go
@@ -144,7 +144,7 @@ func (m *MultiStateMigrator) plan(ctx context.Context) (*tfexec.State, *tfexec.S
 	_, err = m.fromTf.Plan(ctx, fromCurrentState, planOpts...)
 	if err != nil {
 		if exitErr, ok := err.(tfexec.ExitError); ok && exitErr.ExitCode() == 2 {
-			if m.force {
+			if m.force || m.o.GlobalForce {
 				log.Printf("[INFO] [migrator@%s] unexpected diffs, ignoring as force option is true: %s", m.fromTf.Dir(), err)
 				return fromCurrentState, toCurrentState, nil
 			}
@@ -159,7 +159,7 @@ func (m *MultiStateMigrator) plan(ctx context.Context) (*tfexec.State, *tfexec.S
 	_, err = m.toTf.Plan(ctx, toCurrentState, planOpts...)
 	if err != nil {
 		if exitErr, ok := err.(tfexec.ExitError); ok && exitErr.ExitCode() == 2 {
-			if m.force {
+			if m.force || m.o.GlobalForce {
 				log.Printf("[INFO] [migrator@%s] unexpected diffs, ignoring as force option is true: %s", m.toTf.Dir(), err)
 				return fromCurrentState, toCurrentState, nil
 			}


### PR DESCRIPTION
Our release cycle often entails more than just a migration. On TST, features are deployed independently. When releasing to ACC/PRD we have a bit more "big bang" release of deploying all features simultaneously from TST to ACC. Therefore we need to use the force option on ACC/PRD and not on TST.

Now we need to have different migration files for these environments, which is not a good practice. The ability to set a global force via the configuration files (which we have for each environment) would solve this.

I haven't written in Go before, might need some help getting things right ;)