### PR TITLE
Add support for Terraform v1.5

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,9 +39,9 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-        - 1.4.0
+        - 1.5.0
+        - 1.4.6
         - 1.3.9
-        - 1.2.9
         - 0.12.31
     env:
       TERRAFORM_VERSION: ${{ matrix.terraform }}


### PR DESCRIPTION
Terraform v1.5.0 was added to the test matrix and confirmed to pass. There are no implementation-level changes.

One thing to mention is that `terraform init -from-module` is now substantially deprecated, and I have fixed it in the Getting Started Guide in #137.