### PR TITLE
Skip ApplyWithForce test in pre-release

### DIFF
--- a/tfexec/test_helper.go
+++ b/tfexec/test_helper.go
@@ -322,3 +322,20 @@ func MatchTerraformVersion(ctx context.Context, tf TerraformCLI, constraints str
 	}
 	return c.Check(v), nil
 }
+
+// IsPreleaseTerraformVersion returns true if terraform version is a prelease.
+func IsPreleaseTerraformVersion(ctx context.Context, tf TerraformCLI) (bool, error) {
+	tfVersionRaw, err := tf.Version(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to get terraform version: %s", err)
+	}
+	v, err := version.NewVersion(tfVersionRaw)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse terraform version: %s", err)
+	}
+
+	if v.Prerelease() != "" {
+		return true, nil
+	}
+	return false, nil
+}

--- a/tfmigrate/multi_state_migrator_test.go
+++ b/tfmigrate/multi_state_migrator_test.go
@@ -456,6 +456,26 @@ resource "null_resource" "qux2" {}
 		t.Fatalf("expect to have changes in toDir")
 	}
 
+	// A pre-release can only be compared between pre-releases due to the
+	// limitations of the hashicorp/go-version libraries and will not behave as
+	// expected, so skip the following test.
+	// https://github.com/hashicorp/go-version/pull/35
+	fromTfVersioPreRelease, err := tfexec.IsPreleaseTerraformVersion(ctx, fromTf)
+	if err != nil {
+		t.Fatalf("failed to check if terraform version is pre-release in fromDir: %s", err)
+	}
+	if fromTfVersioPreRelease {
+		t.Skip("skip the following test because a pre-release can only be compared between pre-releases")
+	}
+
+	toTfVersioPreRelease, err := tfexec.IsPreleaseTerraformVersion(ctx, toTf)
+	if err != nil {
+		t.Fatalf("failed to check if terraform version is pre-release in toDir: %s", err)
+	}
+	if toTfVersioPreRelease {
+		t.Skip("skip the following test because a pre-release can only be compared between pre-releases")
+	}
+
 	// Note that the saved plan file is not applicable in Terraform 1.1+.
 	// https://github.com/minamijoyo/tfmigrate/pull/63
 	// It's intended to use only for static analysis.

--- a/tfmigrate/state_migrator_test.go
+++ b/tfmigrate/state_migrator_test.go
@@ -340,6 +340,18 @@ resource "null_resource" "baz" {}
 		t.Fatalf("expect to have changes")
 	}
 
+	// A pre-release can only be compared between pre-releases due to the
+	// limitations of the hashicorp/go-version libraries and will not behave as
+	// expected, so skip the following test.
+	// https://github.com/hashicorp/go-version/pull/35
+	tfVersioPreRelease, err := tfexec.IsPreleaseTerraformVersion(ctx, tf)
+	if err != nil {
+		t.Fatalf("failed to check if terraform version is pre-release: %s", err)
+	}
+	if tfVersioPreRelease {
+		t.Skip("skip the following test because a pre-release can only be compared between pre-releases")
+	}
+
 	// Note that the saved plan file is not applicable in Terraform 1.1+.
 	// https://github.com/minamijoyo/tfmigrate/pull/63
 	// It's intended to use only for static analysis.


### PR DESCRIPTION
A pre-release can only be compared between pre-releases due to the limitations of the hashicorp/go-version libraries and will not behave as expected.
https://github.com/hashicorp/go-version/pull/35

On the other hand, the ApplyWithForce test is a legacy one that can only be tested before 1.1 and does not need to be tested on pre-releases 1.1+. So we can skip it if pre-release.