### PR TITLE
Avoid using terraform init -from-module

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ $ docker-compose run --rm tfmigrate /bin/bash
 In the sandbox environment, create and initialize a working directory from test fixtures:
 
 ```
-# mkdir -p tmp/dir1 && cd tmp/dir1
-# terraform init -from-module=../../test-fixtures/backend_s3/
+# mkdir -p tmp && cp -pr test-fixtures/backend_s3 tmp/dir1 && cd tmp/dir1
+# terraform init
 # cat main.tf
 ```
 


### PR DESCRIPTION
Starting from Terraform v1.5-beta, terraform init -from-module emits a warning for ignoring backend config. I asked about this issue in the upstream, and it turned out that the option should not use except for Terragrunt.
https://github.com/hashicorp/terraform/issues/33276

So, I fixed the getting started guide to use simply copying and initializing instead of using the option.