### PR TITLE
Continue to plan to_dir for multi_state if force is true

### DIFF
--- a/tfmigrate/multi_state_migrator.go
+++ b/tfmigrate/multi_state_migrator.go
@@ -144,14 +144,12 @@ func (m *MultiStateMigrator) plan(ctx context.Context) (*tfexec.State, *tfexec.S
 	_, err = m.fromTf.Plan(ctx, fromCurrentState, planOpts...)
 	if err != nil {
 		if exitErr, ok := err.(tfexec.ExitError); ok && exitErr.ExitCode() == 2 {
-			if m.force {
-				log.Printf("[INFO] [migrator@%s] unexpected diffs, ignoring as force option is true: %s", m.fromTf.Dir(), err)
-				return fromCurrentState, toCurrentState, nil
+			if !m.force {
+				log.Printf("[ERROR] [migrator@%s] unexpected diffs\n", m.fromTf.Dir())
+				return nil, nil, fmt.Errorf("terraform plan command returns unexpected diffs: %s", err)
 			}
-			log.Printf("[ERROR] [migrator@%s] unexpected diffs\n", m.fromTf.Dir())
-			return nil, nil, fmt.Errorf("terraform plan command returns unexpected diffs: %s", err)
+			log.Printf("[INFO] [migrator@%s] unexpected diffs, ignoring as force option is true: %s", m.fromTf.Dir(), err)
 		}
-		return nil, nil, err
 	}
 
 	// check if a plan in toDir has no changes.
@@ -159,14 +157,12 @@ func (m *MultiStateMigrator) plan(ctx context.Context) (*tfexec.State, *tfexec.S
 	_, err = m.toTf.Plan(ctx, toCurrentState, planOpts...)
 	if err != nil {
 		if exitErr, ok := err.(tfexec.ExitError); ok && exitErr.ExitCode() == 2 {
-			if m.force {
-				log.Printf("[INFO] [migrator@%s] unexpected diffs, ignoring as force option is true: %s", m.toTf.Dir(), err)
-				return fromCurrentState, toCurrentState, nil
+			if !m.force {
+				log.Printf("[ERROR] [migrator@%s] unexpected diffs\n", m.toTf.Dir())
+				return nil, nil, fmt.Errorf("terraform plan command returns unexpected diffs: %s", err)
 			}
-			log.Printf("[ERROR] [migrator@%s] unexpected diffs\n", m.toTf.Dir())
-			return nil, nil, fmt.Errorf("terraform plan command returns unexpected diffs: %s", err)
+			log.Printf("[INFO] [migrator@%s] unexpected diffs, ignoring as force option is true: %s", m.toTf.Dir(), err)
 		}
-		return nil, nil, err
 	}
 
 	return fromCurrentState, toCurrentState, nil


### PR DESCRIPTION
## What

In `multi_state` mode, `from_dir` will be planned first before planning the `to_dir`. When `force = true` and there are unexpected diffs for the `from_dir`, the check for the `to_dir` will be skipped. 

If `to_dir` check is skipped in this case, we wont be able to confirm any unexpected changes.

This PR addresses this issue by ensuring that both `from_dir` and `to_dir` will be checked.

## How

If `force = true` and there are unexpected diffs in the `from_dir` plan check, instead of returning the function immediately, continue to check `to_dir`.
