### PR TITLE
Fix a regression issue of error handling in multi_state migration

### DIFF
--- a/tfmigrate/multi_state_migrator.go
+++ b/tfmigrate/multi_state_migrator.go
@@ -149,6 +149,8 @@ func (m *MultiStateMigrator) plan(ctx context.Context) (*tfexec.State, *tfexec.S
 				return nil, nil, fmt.Errorf("terraform plan command returns unexpected diffs: %s", err)
 			}
 			log.Printf("[INFO] [migrator@%s] unexpected diffs, ignoring as force option is true: %s", m.fromTf.Dir(), err)
+		} else {
+			return nil, nil, err
 		}
 	}
 
@@ -162,6 +164,8 @@ func (m *MultiStateMigrator) plan(ctx context.Context) (*tfexec.State, *tfexec.S
 				return nil, nil, fmt.Errorf("terraform plan command returns unexpected diffs: %s", err)
 			}
 			log.Printf("[INFO] [migrator@%s] unexpected diffs, ignoring as force option is true: %s", m.toTf.Dir(), err)
+		} else {
+			return nil, nil, err
 		}
 	}
 

--- a/tfmigrate/state_migrator.go
+++ b/tfmigrate/state_migrator.go
@@ -133,14 +133,14 @@ func (m *StateMigrator) plan(ctx context.Context) (*tfexec.State, error) {
 	_, err = m.tf.Plan(ctx, currentState, planOpts...)
 	if err != nil {
 		if exitErr, ok := err.(tfexec.ExitError); ok && exitErr.ExitCode() == 2 {
-			if m.force {
-				log.Printf("[INFO] [migrator@%s] unexpected diffs, ignoring as force option is true: %s", m.tf.Dir(), err)
-				return currentState, nil
+			if !m.force {
+				log.Printf("[ERROR] [migrator@%s] unexpected diffs\n", m.tf.Dir())
+				return nil, fmt.Errorf("terraform plan command returns unexpected diffs: %s", err)
 			}
-			log.Printf("[ERROR] [migrator@%s] unexpected diffs\n", m.tf.Dir())
-			return nil, fmt.Errorf("terraform plan command returns unexpected diffs: %s", err)
+			log.Printf("[INFO] [migrator@%s] unexpected diffs, ignoring as force option is true: %s", m.tf.Dir(), err)
+		} else {
+			return nil, err
 		}
-		return nil, err
 	}
 
 	return currentState, nil


### PR DESCRIPTION
Fixes #140

We slightly fixed the behavior of the force option in #139, but the fix introduced a regression in error handling; errors in plan commands, except for detected diffs, should not be ignored regardless of force or not.

A single-state migration implementation did not have this bug because it had a similar but different implementation, but I'll take this opportunity to use the same logic.