### PR TITLE
support conditionally disabling `terraform plan`-ing

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,8 +638,10 @@ migration "state" "test" {
 The `multi_state` migration updates states in two different directories. It is intended for moving resources across states. It has the following attributes.
 
 - `from_dir` (required): A working directory where states of resources move from.
+- `disable_from_dir_diff_check` (optional): If true, `tfmigrate` will not perform and analyze a `terraform plan` in the `from_dir`.
 - `from_workspace` (optional): A terraform workspace in the FROM directory. Defaults to "default".
 - `to_dir` (required): A working directory where states of resources move to.
+- `disable_to_dir_diff_check` (optional): If true, `tfmigrate` will not perform and analyze a `terraform plan` in the `to_dir`.
 - `to_workspace` (optional): A terraform workspace in the TO directory. Defaults to "default".
 - `actions` (required): Actions is a list of multi state action. An action is a plain text for state operation. Valid formats are the following.
   - `"mv <source> <destination>"`

--- a/README.md
+++ b/README.md
@@ -638,10 +638,10 @@ migration "state" "test" {
 The `multi_state` migration updates states in two different directories. It is intended for moving resources across states. It has the following attributes.
 
 - `from_dir` (required): A working directory where states of resources move from.
-- `disable_from_dir_diff_check` (optional): If true, `tfmigrate` will not perform and analyze a `terraform plan` in the `from_dir`.
+- `from_skip_plan` (optional): If true, `tfmigrate` will not perform and analyze a `terraform plan` in the `from_dir`.
 - `from_workspace` (optional): A terraform workspace in the FROM directory. Defaults to "default".
 - `to_dir` (required): A working directory where states of resources move to.
-- `disable_to_dir_diff_check` (optional): If true, `tfmigrate` will not perform and analyze a `terraform plan` in the `to_dir`.
+- `to_skip_plan` (optional): If true, `tfmigrate` will not perform and analyze a `terraform plan` in the `to_dir`.
 - `to_workspace` (optional): A terraform workspace in the TO directory. Defaults to "default".
 - `actions` (required): Actions is a list of multi state action. An action is a plain text for state operation. Valid formats are the following.
   - `"mv <source> <destination>"`

--- a/tfmigrate/multi_state_migrator.go
+++ b/tfmigrate/multi_state_migrator.go
@@ -152,6 +152,8 @@ func (m *MultiStateMigrator) plan(ctx context.Context) (*tfexec.State, *tfexec.S
 	}
 
 	if m.fromSkipPlan {
+		log.Printf("[INFO] [migrator@%s] skipping check diffs\n", m.fromTf.Dir())
+	} else {
 		// check if a plan in fromDir has no changes.
 		log.Printf("[INFO] [migrator@%s] check diffs\n", m.fromTf.Dir())
 		_, err = m.fromTf.Plan(ctx, fromCurrentState, planOpts...)
@@ -159,18 +161,18 @@ func (m *MultiStateMigrator) plan(ctx context.Context) (*tfexec.State, *tfexec.S
 			if exitErr, ok := err.(tfexec.ExitError); ok && exitErr.ExitCode() == 2 {
 				if !m.force {
 					log.Printf("[ERROR] [migrator@%s] unexpected diffs\n", m.fromTf.Dir())
-					return nil, nil, fmt.Errorf("terraform plan command returns unexpected diffs: %s", err)
+					return nil, nil, fmt.Errorf("terraform plan command returns unexpected diffs in %s from_dir: %s", m.fromTf.Dir(), err)
 				}
 				log.Printf("[INFO] [migrator@%s] unexpected diffs, ignoring as force option is true: %s", m.fromTf.Dir(), err)
 			} else {
 				return nil, nil, err
 			}
 		}
-	} else {
-		log.Printf("[INFO] [migrator@%s] skipping check diffs\n", m.fromTf.Dir())
 	}
 
 	if m.toSkipPlan {
+		log.Printf("[INFO] [migrator@%s] skipping check diffs\n", m.toTf.Dir())
+	} else {
 		// check if a plan in toDir has no changes.
 		log.Printf("[INFO] [migrator@%s] check diffs\n", m.toTf.Dir())
 		_, err = m.toTf.Plan(ctx, toCurrentState, planOpts...)
@@ -178,15 +180,13 @@ func (m *MultiStateMigrator) plan(ctx context.Context) (*tfexec.State, *tfexec.S
 			if exitErr, ok := err.(tfexec.ExitError); ok && exitErr.ExitCode() == 2 {
 				if !m.force {
 					log.Printf("[ERROR] [migrator@%s] unexpected diffs\n", m.toTf.Dir())
-					return nil, nil, fmt.Errorf("terraform plan command returns unexpected diffs: %s", err)
+					return nil, nil, fmt.Errorf("terraform plan command returns unexpected diffs in %s to_dir: %s", m.toTf.Dir(), err)
 				}
 				log.Printf("[INFO] [migrator@%s] unexpected diffs, ignoring as force option is true: %s", m.toTf.Dir(), err)
 			} else {
 				return nil, nil, err
 			}
 		}
-	} else {
-		log.Printf("[INFO] [migrator@%s] skipping check diffs\n", m.toTf.Dir())
 	}
 
 	return fromCurrentState, toCurrentState, nil

--- a/tfmigrate/multi_state_migrator_test.go
+++ b/tfmigrate/multi_state_migrator_test.go
@@ -373,8 +373,8 @@ resource "null_resource" "qux" {}
 	if err != nil {
 		t.Fatalf("failed to run PlanHasChange in fromDir: %s", err)
 	}
-	if fromChanged {
-		t.Error("expect not to have changes in fromDir")
+	if !fromChanged {
+		t.Error("expect to have changes in fromDir")
 	}
 
 	toChanged, err = toTf.PlanHasChange(ctx, nil)
@@ -429,8 +429,8 @@ resource "null_resource" "baz" {}
 	if err != nil {
 		t.Fatalf("failed to run PlanHasChange in toDir: %s", err)
 	}
-	if !toChanged {
-		t.Fatalf("expect to have changes in toDir")
+	if toChanged {
+		t.Fatalf("expect not to have changes in toDir")
 	}
 
 	// perform state migration
@@ -492,8 +492,8 @@ resource "null_resource" "baz" {}
 	if err != nil {
 		t.Fatalf("failed to run PlanHasChange in toDir: %s", err)
 	}
-	if toChanged {
-		t.Error("expect not to have changes in toDir")
+	if !toChanged {
+		t.Error("expect to have changes in toDir")
 	}
 }
 
@@ -531,16 +531,16 @@ resource "null_resource" "qux" {}
 	if err != nil {
 		t.Fatalf("failed to run PlanHasChange in fromDir: %s", err)
 	}
-	if !fromChanged {
-		t.Fatalf("expect to have changes in fromDir")
+	if fromChanged {
+		t.Fatalf("expect not to have changes in fromDir")
 	}
 
 	toChanged, err := toTf.PlanHasChange(ctx, nil)
 	if err != nil {
 		t.Fatalf("failed to run PlanHasChange in toDir: %s", err)
 	}
-	if !toChanged {
-		t.Fatalf("expect to have changes in toDir")
+	if toChanged {
+		t.Fatalf("expect not to have changes in toDir")
 	}
 
 	// perform state migration
@@ -594,16 +594,16 @@ resource "null_resource" "qux" {}
 	if err != nil {
 		t.Fatalf("failed to run PlanHasChange in fromDir: %s", err)
 	}
-	if fromChanged {
-		t.Error("expect not to have changes in fromDir")
+	if !fromChanged {
+		t.Error("expect to have changes in fromDir")
 	}
 
 	toChanged, err = toTf.PlanHasChange(ctx, nil)
 	if err != nil {
 		t.Fatalf("failed to run PlanHasChange in toDir: %s", err)
 	}
-	if toChanged {
-		t.Error("expect not to have changes in toDir")
+	if !toChanged {
+		t.Error("expect to have changes in toDir")
 	}
 }
 

--- a/tfmigrate/multi_state_migrator_test.go
+++ b/tfmigrate/multi_state_migrator_test.go
@@ -36,9 +36,9 @@ func TestMultiStateMigratorConfigNewMigrator(t *testing.T) {
 		{
 			desc: "valid and default workspace, with diff check disabled in from dir",
 			config: &MultiStateMigratorConfig{
-				FromDir:                 "dir1",
-				DisableFromDirDiffCheck: true,
-				ToDir:                   "dir2",
+				FromDir:      "dir1",
+				FromSkipPlan: true,
+				ToDir:        "dir2",
 				Actions: []string{
 					"mv null_resource.foo null_resource.foo2",
 					"mv null_resource.bar null_resource.bar2",
@@ -52,9 +52,9 @@ func TestMultiStateMigratorConfigNewMigrator(t *testing.T) {
 		{
 			desc: "valid and default workspace, with diff check disabled in to dir",
 			config: &MultiStateMigratorConfig{
-				FromDir:               "dir1",
-				ToDir:                 "dir2",
-				DisableToDirDiffCheck: true,
+				FromDir:    "dir1",
+				ToDir:      "dir2",
+				ToSkipPlan: true,
 				Actions: []string{
 					"mv null_resource.foo null_resource.foo2",
 					"mv null_resource.bar null_resource.bar2",
@@ -68,10 +68,10 @@ func TestMultiStateMigratorConfigNewMigrator(t *testing.T) {
 		{
 			desc: "valid and default workspace, with diff check disabled in from and to dirs",
 			config: &MultiStateMigratorConfig{
-				FromDir:                 "dir1",
-				DisableFromDirDiffCheck: true,
-				ToDir:                   "dir2",
-				DisableToDirDiffCheck:   true,
+				FromDir:      "dir1",
+				FromSkipPlan: true,
+				ToDir:        "dir2",
+				ToSkipPlan:   true,
 				Actions: []string{
 					"mv null_resource.foo null_resource.foo2",
 					"mv null_resource.bar null_resource.bar2",
@@ -273,7 +273,7 @@ resource "null_resource" "qux" {}
 	}
 }
 
-func TestAccMultiStateMigratorApplyWithDisableFromDirDiffCheck(t *testing.T) {
+func TestAccMultiStateMigratorApplyWithFromSkipPlan(t *testing.T) {
 	tfexec.SkipUnlessAcceptanceTestEnabled(t)
 	ctx := context.Background()
 
@@ -386,7 +386,7 @@ resource "null_resource" "qux" {}
 	}
 }
 
-func TestAccMultiStateMigratorApplyWithDisableToDirDiffCheck(t *testing.T) {
+func TestAccMultiStateMigratorApplyWithToSkipPlan(t *testing.T) {
 	tfexec.SkipUnlessAcceptanceTestEnabled(t)
 	ctx := context.Background()
 
@@ -497,7 +497,7 @@ resource "null_resource" "baz" {}
 	}
 }
 
-func TestAccMultiStateMigratorApplyWithDisableDiffCheck(t *testing.T) {
+func TestAccMultiStateMigratorApplyWithSkipPlan(t *testing.T) {
 	tfexec.SkipUnlessAcceptanceTestEnabled(t)
 	ctx := context.Background()
 

--- a/tfmigrate/multi_state_migrator_test.go
+++ b/tfmigrate/multi_state_migrator_test.go
@@ -310,8 +310,8 @@ resource "null_resource" "qux" {}
 	if err != nil {
 		t.Fatalf("failed to run PlanHasChange in fromDir: %s", err)
 	}
-	if !fromChanged {
-		t.Fatalf("expect to have changes in fromDir")
+	if fromChanged {
+		t.Fatalf("expect not to have changes in fromDir")
 	}
 
 	toChanged, err := toTf.PlanHasChange(ctx, nil)

--- a/tfmigrate/multi_state_migrator_test.go
+++ b/tfmigrate/multi_state_migrator_test.go
@@ -34,6 +34,55 @@ func TestMultiStateMigratorConfigNewMigrator(t *testing.T) {
 			ok: true,
 		},
 		{
+			desc: "valid and default workspace, with diff check disabled in from dir",
+			config: &MultiStateMigratorConfig{
+				FromDir:                 "dir1",
+				DisableFromDirDiffCheck: true,
+				ToDir:                   "dir2",
+				Actions: []string{
+					"mv null_resource.foo null_resource.foo2",
+					"mv null_resource.bar null_resource.bar2",
+				},
+			},
+			o: &MigratorOption{
+				ExecPath: "direnv exec . terraform",
+			},
+			ok: true,
+		},
+		{
+			desc: "valid and default workspace, with diff check disabled in to dir",
+			config: &MultiStateMigratorConfig{
+				FromDir:               "dir1",
+				ToDir:                 "dir2",
+				DisableToDirDiffCheck: true,
+				Actions: []string{
+					"mv null_resource.foo null_resource.foo2",
+					"mv null_resource.bar null_resource.bar2",
+				},
+			},
+			o: &MigratorOption{
+				ExecPath: "direnv exec . terraform",
+			},
+			ok: true,
+		},
+		{
+			desc: "valid and default workspace, with diff check disabled in from and to dirs",
+			config: &MultiStateMigratorConfig{
+				FromDir:                 "dir1",
+				DisableFromDirDiffCheck: true,
+				ToDir:                   "dir2",
+				DisableToDirDiffCheck:   true,
+				Actions: []string{
+					"mv null_resource.foo null_resource.foo2",
+					"mv null_resource.bar null_resource.bar2",
+				},
+			},
+			o: &MigratorOption{
+				ExecPath: "direnv exec . terraform",
+			},
+			ok: true,
+		},
+		{
 			desc: "valid and custom workspace",
 			config: &MultiStateMigratorConfig{
 				FromDir:       "dir1",
@@ -167,7 +216,341 @@ resource "null_resource" "qux" {}
 	}
 	o := &MigratorOption{}
 	force := false
-	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force)
+	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, false, false)
+	err = m.Plan(ctx)
+	if err != nil {
+		t.Fatalf("failed to run migrator plan: %s", err)
+	}
+
+	err = m.Apply(ctx)
+	if err != nil {
+		t.Fatalf("failed to run migrator apply: %s", err)
+	}
+
+	// verify state migration results
+	fromGot, err := fromTf.StateList(ctx, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to run terraform state list in fromDir: %s", err)
+	}
+	fromWant := []string{
+		"null_resource.baz",
+	}
+	sort.Strings(fromGot)
+	sort.Strings(fromWant)
+	if !reflect.DeepEqual(fromGot, fromWant) {
+		t.Errorf("got state: %v, want state: %v in fromDir", fromGot, fromWant)
+	}
+
+	toGot, err := toTf.StateList(ctx, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to run terraform state list in toDir: %s", err)
+	}
+	toWant := []string{
+		"null_resource.foo",
+		"null_resource.bar2",
+		"null_resource.qux",
+	}
+	sort.Strings(toGot)
+	sort.Strings(toWant)
+	if !reflect.DeepEqual(toGot, toWant) {
+		t.Errorf("got state: %v, want state: %v in toDir", toGot, toWant)
+	}
+
+	fromChanged, err = fromTf.PlanHasChange(ctx, nil)
+	if err != nil {
+		t.Fatalf("failed to run PlanHasChange in fromDir: %s", err)
+	}
+	if fromChanged {
+		t.Error("expect not to have changes in fromDir")
+	}
+
+	toChanged, err = toTf.PlanHasChange(ctx, nil)
+	if err != nil {
+		t.Fatalf("failed to run PlanHasChange in toDir: %s", err)
+	}
+	if toChanged {
+		t.Error("expect not to have changes in toDir")
+	}
+}
+
+func TestAccMultiStateMigratorApplyWithDisableFromDirDiffCheck(t *testing.T) {
+	tfexec.SkipUnlessAcceptanceTestEnabled(t)
+	ctx := context.Background()
+
+	// setup the initial files and states
+	fromBackend := tfexec.GetTestAccBackendS3Config(t.Name() + "/fromDir")
+	fromSource := `
+resource "null_resource" "foo" {}
+resource "null_resource" "bar" {}
+resource "null_resource" "baz" {}
+`
+	fromWorkspace := "default"
+	fromTf := tfexec.SetupTestAccWithApply(t, fromWorkspace, fromBackend+fromSource)
+
+	toBackend := tfexec.GetTestAccBackendS3Config(t.Name() + "/toDir")
+	toSource := `
+resource "null_resource" "qux" {}
+`
+	toWorkspace := "default"
+	toTf := tfexec.SetupTestAccWithApply(t, toWorkspace, toBackend+toSource)
+
+	// update terraform resource files for migration
+	fromUpdatedSource := fromSource
+
+	tfexec.UpdateTestAccSource(t, fromTf, fromBackend+fromUpdatedSource)
+
+	toUpdatedSource := `
+resource "null_resource" "foo" {}
+resource "null_resource" "bar2" {}
+resource "null_resource" "qux" {}
+`
+	tfexec.UpdateTestAccSource(t, toTf, toBackend+toUpdatedSource)
+
+	fromChanged, err := fromTf.PlanHasChange(ctx, nil)
+	if err != nil {
+		t.Fatalf("failed to run PlanHasChange in fromDir: %s", err)
+	}
+	if !fromChanged {
+		t.Fatalf("expect to have changes in fromDir")
+	}
+
+	toChanged, err := toTf.PlanHasChange(ctx, nil)
+	if err != nil {
+		t.Fatalf("failed to run PlanHasChange in toDir: %s", err)
+	}
+	if !toChanged {
+		t.Fatalf("expect to have changes in toDir")
+	}
+
+	// perform state migration
+	actions := []MultiStateAction{
+		NewMultiStateMvAction("null_resource.foo", "null_resource.foo"),
+		NewMultiStateMvAction("null_resource.bar", "null_resource.bar2"),
+	}
+	o := &MigratorOption{}
+	force := false
+	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, true, false)
+	err = m.Plan(ctx)
+	if err != nil {
+		t.Fatalf("failed to run migrator plan: %s", err)
+	}
+
+	err = m.Apply(ctx)
+	if err != nil {
+		t.Fatalf("failed to run migrator apply: %s", err)
+	}
+
+	// verify state migration results
+	fromGot, err := fromTf.StateList(ctx, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to run terraform state list in fromDir: %s", err)
+	}
+	fromWant := []string{
+		"null_resource.baz",
+	}
+	sort.Strings(fromGot)
+	sort.Strings(fromWant)
+	if !reflect.DeepEqual(fromGot, fromWant) {
+		t.Errorf("got state: %v, want state: %v in fromDir", fromGot, fromWant)
+	}
+
+	toGot, err := toTf.StateList(ctx, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to run terraform state list in toDir: %s", err)
+	}
+	toWant := []string{
+		"null_resource.foo",
+		"null_resource.bar2",
+		"null_resource.qux",
+	}
+	sort.Strings(toGot)
+	sort.Strings(toWant)
+	if !reflect.DeepEqual(toGot, toWant) {
+		t.Errorf("got state: %v, want state: %v in toDir", toGot, toWant)
+	}
+
+	fromChanged, err = fromTf.PlanHasChange(ctx, nil)
+	if err != nil {
+		t.Fatalf("failed to run PlanHasChange in fromDir: %s", err)
+	}
+	if fromChanged {
+		t.Error("expect not to have changes in fromDir")
+	}
+
+	toChanged, err = toTf.PlanHasChange(ctx, nil)
+	if err != nil {
+		t.Fatalf("failed to run PlanHasChange in toDir: %s", err)
+	}
+	if toChanged {
+		t.Error("expect not to have changes in toDir")
+	}
+}
+
+func TestAccMultiStateMigratorApplyWithDisableToDirDiffCheck(t *testing.T) {
+	tfexec.SkipUnlessAcceptanceTestEnabled(t)
+	ctx := context.Background()
+
+	// setup the initial files and states
+	fromBackend := tfexec.GetTestAccBackendS3Config(t.Name() + "/fromDir")
+	fromSource := `
+resource "null_resource" "foo" {}
+resource "null_resource" "bar" {}
+resource "null_resource" "baz" {}
+`
+	fromWorkspace := "default"
+	fromTf := tfexec.SetupTestAccWithApply(t, fromWorkspace, fromBackend+fromSource)
+
+	toBackend := tfexec.GetTestAccBackendS3Config(t.Name() + "/toDir")
+	toSource := `
+resource "null_resource" "qux" {}
+`
+	toWorkspace := "default"
+	toTf := tfexec.SetupTestAccWithApply(t, toWorkspace, toBackend+toSource)
+
+	// update terraform resource files for migration
+	fromUpdatedSource := `
+resource "null_resource" "baz" {}
+`
+	tfexec.UpdateTestAccSource(t, fromTf, fromBackend+fromUpdatedSource)
+
+	toUpdatedSource := toSource
+
+	tfexec.UpdateTestAccSource(t, toTf, toBackend+toUpdatedSource)
+
+	fromChanged, err := fromTf.PlanHasChange(ctx, nil)
+	if err != nil {
+		t.Fatalf("failed to run PlanHasChange in fromDir: %s", err)
+	}
+	if !fromChanged {
+		t.Fatalf("expect to have changes in fromDir")
+	}
+
+	toChanged, err := toTf.PlanHasChange(ctx, nil)
+	if err != nil {
+		t.Fatalf("failed to run PlanHasChange in toDir: %s", err)
+	}
+	if !toChanged {
+		t.Fatalf("expect to have changes in toDir")
+	}
+
+	// perform state migration
+	actions := []MultiStateAction{
+		NewMultiStateMvAction("null_resource.foo", "null_resource.foo"),
+		NewMultiStateMvAction("null_resource.bar", "null_resource.bar2"),
+	}
+	o := &MigratorOption{}
+	force := false
+	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, false, true)
+	err = m.Plan(ctx)
+	if err != nil {
+		t.Fatalf("failed to run migrator plan: %s", err)
+	}
+
+	err = m.Apply(ctx)
+	if err != nil {
+		t.Fatalf("failed to run migrator apply: %s", err)
+	}
+
+	// verify state migration results
+	fromGot, err := fromTf.StateList(ctx, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to run terraform state list in fromDir: %s", err)
+	}
+	fromWant := []string{
+		"null_resource.baz",
+	}
+	sort.Strings(fromGot)
+	sort.Strings(fromWant)
+	if !reflect.DeepEqual(fromGot, fromWant) {
+		t.Errorf("got state: %v, want state: %v in fromDir", fromGot, fromWant)
+	}
+
+	toGot, err := toTf.StateList(ctx, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to run terraform state list in toDir: %s", err)
+	}
+	toWant := []string{
+		"null_resource.foo",
+		"null_resource.bar2",
+		"null_resource.qux",
+	}
+	sort.Strings(toGot)
+	sort.Strings(toWant)
+	if !reflect.DeepEqual(toGot, toWant) {
+		t.Errorf("got state: %v, want state: %v in toDir", toGot, toWant)
+	}
+
+	fromChanged, err = fromTf.PlanHasChange(ctx, nil)
+	if err != nil {
+		t.Fatalf("failed to run PlanHasChange in fromDir: %s", err)
+	}
+	if fromChanged {
+		t.Error("expect not to have changes in fromDir")
+	}
+
+	toChanged, err = toTf.PlanHasChange(ctx, nil)
+	if err != nil {
+		t.Fatalf("failed to run PlanHasChange in toDir: %s", err)
+	}
+	if toChanged {
+		t.Error("expect not to have changes in toDir")
+	}
+}
+
+func TestAccMultiStateMigratorApplyWithDisableDiffCheck(t *testing.T) {
+	tfexec.SkipUnlessAcceptanceTestEnabled(t)
+	ctx := context.Background()
+
+	// setup the initial files and states
+	fromBackend := tfexec.GetTestAccBackendS3Config(t.Name() + "/fromDir")
+	fromSource := `
+resource "null_resource" "foo" {}
+resource "null_resource" "bar" {}
+resource "null_resource" "baz" {}
+`
+	fromWorkspace := "default"
+	fromTf := tfexec.SetupTestAccWithApply(t, fromWorkspace, fromBackend+fromSource)
+
+	toBackend := tfexec.GetTestAccBackendS3Config(t.Name() + "/toDir")
+	toSource := `
+resource "null_resource" "qux" {}
+`
+	toWorkspace := "default"
+	toTf := tfexec.SetupTestAccWithApply(t, toWorkspace, toBackend+toSource)
+
+	// update terraform resource files for migration
+	fromUpdatedSource := fromSource
+
+	tfexec.UpdateTestAccSource(t, fromTf, fromBackend+fromUpdatedSource)
+
+	toUpdatedSource := toSource
+
+	tfexec.UpdateTestAccSource(t, toTf, toBackend+toUpdatedSource)
+
+	fromChanged, err := fromTf.PlanHasChange(ctx, nil)
+	if err != nil {
+		t.Fatalf("failed to run PlanHasChange in fromDir: %s", err)
+	}
+	if !fromChanged {
+		t.Fatalf("expect to have changes in fromDir")
+	}
+
+	toChanged, err := toTf.PlanHasChange(ctx, nil)
+	if err != nil {
+		t.Fatalf("failed to run PlanHasChange in toDir: %s", err)
+	}
+	if !toChanged {
+		t.Fatalf("expect to have changes in toDir")
+	}
+
+	// perform state migration
+	actions := []MultiStateAction{
+		NewMultiStateMvAction("null_resource.foo", "null_resource.foo"),
+		NewMultiStateMvAction("null_resource.bar", "null_resource.bar2"),
+	}
+	o := &MigratorOption{}
+	force := false
+	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, true, true)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)
@@ -281,7 +664,7 @@ resource "null_resource" "qux" {}
 	}
 	o := &MigratorOption{}
 	force := false
-	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force)
+	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, false, false)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)
@@ -400,7 +783,7 @@ resource "null_resource" "qux2" {}
 	o := &MigratorOption{}
 	o.PlanOut = "foo.tfplan"
 	force := true
-	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force)
+	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, false, false)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)

--- a/tfmigrate/multi_state_mv_action_test.go
+++ b/tfmigrate/multi_state_mv_action_test.go
@@ -64,7 +64,7 @@ resource "null_resource" "qux" {}
 	}
 	o := &MigratorOption{}
 	force := false
-	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force)
+	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, false, false)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)

--- a/tfmigrate/multi_state_xmv_action_test.go
+++ b/tfmigrate/multi_state_xmv_action_test.go
@@ -63,7 +63,7 @@ resource "null_resource" "qux" {}
 	}
 	o := &MigratorOption{}
 	force := false
-	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force)
+	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, false, false)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)


### PR DESCRIPTION
👋 This seeks to address issue #142 by adding two fields to `MultiStateMigratorConfig`:

* `from_skip_plan` - when `true`, `tfmigrator` skips running `terraform plan` in the `from_dir`. Default: `false`.
* `to_skip_plan` - when `true`, `tfmigrator` skips running `terraform plan` in the `to_dir`. Default: `false`.

Example:

```hcl
migration "multi_state" "test" {
  from_dir       = "."
  from_skip_plan = true

  to_dir       = "dir2"
  to_skip_plan = true

  actions = [
    "mv aws_security_group.baz aws_security_group.baz2",
  ]
}
```