### PR TITLE
exercise Apply during acceptance tests

### DIFF
--- a/tfmigrate/multi_state_mv_action_test.go
+++ b/tfmigrate/multi_state_mv_action_test.go
@@ -69,4 +69,9 @@ resource "null_resource" "qux" {}
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)
 	}
+
+	err = m.Apply(ctx)
+	if err != nil {
+		t.Fatalf("failed to run migrator apply: %s", err)
+	}
 }

--- a/tfmigrate/multi_state_xmv_action_test.go
+++ b/tfmigrate/multi_state_xmv_action_test.go
@@ -68,4 +68,9 @@ resource "null_resource" "qux" {}
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)
 	}
+
+	err = m.Apply(ctx)
+	if err != nil {
+		t.Fatalf("failed to run migrator plan: %s", err)
+	}
 }

--- a/tfmigrate/state_mv_action_test.go
+++ b/tfmigrate/state_mv_action_test.go
@@ -48,4 +48,9 @@ resource "null_resource" "baz" {}
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)
 	}
+
+	err = m.Apply(ctx)
+	if err != nil {
+		t.Fatalf("failed to run migrator apply: %s", err)
+	}
 }

--- a/tfmigrate/state_xmv_action_test.go
+++ b/tfmigrate/state_xmv_action_test.go
@@ -44,4 +44,9 @@ resource "null_resource" "bar2" {}
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)
 	}
+
+	err = m.Apply(ctx)
+	if err != nil {
+		t.Fatalf("failed to run migrator apply: %s", err)
+	}
 }


### PR DESCRIPTION
This ensures various tfmigrate acceptance tests exercise `apply`, as well as `plan`.