### PR TITLE
avoid suppressing errors in deferred funcs

### DIFF
--- a/tfexec/terraform_test.go
+++ b/tfexec/terraform_test.go
@@ -131,7 +131,7 @@ resource "null_resource" "bar" {}
 		t.Fatalf("failed to determine if Terraform version supports state replace-provider: %s", err)
 	}
 
-	switchBackToRemotekFunc, err := terraformCLI.OverrideBackendToLocal(context.Background(), filename, workspace, false, nil, supportsStateReplaceProvider)
+	switchBackToRemoteFunc, err := terraformCLI.OverrideBackendToLocal(context.Background(), filename, workspace, false, nil, supportsStateReplaceProvider)
 	if err != nil {
 		t.Fatalf("failed to run OverrideBackendToLocal: %s", err)
 	}
@@ -153,7 +153,10 @@ resource "null_resource" "bar" {}
 		t.Fatalf("expect not to have changes")
 	}
 
-	switchBackToRemotekFunc()
+	err = switchBackToRemoteFunc()
+	if err != nil {
+		t.Fatalf("unexpected err switching back to remote backend: %s", err)
+	}
 
 	if _, err := os.Stat(filepath.Join(terraformCLI.Dir(), filename)); err == nil {
 		t.Fatalf("the override file wasn't removed: %s", err)
@@ -264,7 +267,7 @@ resource "null_resource" "bar" {}
 		t.Fatalf("failed to determine if Terraform version supports state replace-provider: %s", err)
 	}
 
-	switchBackToRemotekFunc, err := terraformCLI.OverrideBackendToLocal(context.Background(), filename, workspace, false, backendConfig, supportsStateReplaceProvider)
+	switchBackToRemoteFunc, err := terraformCLI.OverrideBackendToLocal(context.Background(), filename, workspace, false, backendConfig, supportsStateReplaceProvider)
 	if err != nil {
 		t.Fatalf("failed to run OverrideBackendToLocal: %s", err)
 	}
@@ -286,7 +289,10 @@ resource "null_resource" "bar" {}
 		t.Fatalf("expect not to have changes")
 	}
 
-	switchBackToRemotekFunc()
+	err = switchBackToRemoteFunc()
+	if err != nil {
+		t.Fatalf("unexpected err switching back to remote backend: %s", err)
+	}
 
 	if _, err := os.Stat(filepath.Join(terraformCLI.Dir(), filename)); err == nil {
 		t.Fatalf("the override file wasn't removed: %s", err)

--- a/tfmigrate/migrator.go
+++ b/tfmigrate/migrator.go
@@ -23,7 +23,7 @@ type Migrator interface {
 
 // setupWorkDir is a common helper function to set up work dir and returns the
 // current state and a switch back function.
-func setupWorkDir(ctx context.Context, tf tfexec.TerraformCLI, workspace string, isBackendTerraformCloud bool, backendConfig []string, ignoreLegacyStateInitErr bool) (*tfexec.State, func(), error) {
+func setupWorkDir(ctx context.Context, tf tfexec.TerraformCLI, workspace string, isBackendTerraformCloud bool, backendConfig []string, ignoreLegacyStateInitErr bool) (*tfexec.State, func() error, error) {
 	// check if terraform command is available.
 	version, err := tf.Version(ctx)
 	if err != nil {

--- a/tfmigrate/multi_state_migrator.go
+++ b/tfmigrate/multi_state_migrator.go
@@ -170,6 +170,8 @@ func (m *MultiStateMigrator) plan(ctx context.Context) (fromCurrentState *tfexec
 					return nil, nil, fmt.Errorf("terraform plan command returns unexpected diffs in %s from_dir: %s", m.fromTf.Dir(), err)
 				}
 				log.Printf("[INFO] [migrator@%s] unexpected diffs, ignoring as force option is true: %s", m.fromTf.Dir(), err)
+				// reset err to nil to intentionally ignore unexpected diffs.
+				err = nil
 			} else {
 				return nil, nil, err
 			}
@@ -188,7 +190,6 @@ func (m *MultiStateMigrator) plan(ctx context.Context) (fromCurrentState *tfexec
 					log.Printf("[ERROR] [migrator@%s] unexpected diffs\n", m.toTf.Dir())
 					return nil, nil, fmt.Errorf("terraform plan command returns unexpected diffs in %s to_dir: %s", m.toTf.Dir(), err)
 				}
-
 				log.Printf("[INFO] [migrator@%s] unexpected diffs, ignoring as force option is true: %s", m.toTf.Dir(), err)
 				// reset err to nil to intentionally ignore unexpected diffs.
 				err = nil


### PR DESCRIPTION
This seeks to address issue #129 by exiting nonzero if ever the `defer`'d `switchBackToRemoteFunc` funcs return an error.

By using a closure in concert with `errors.Join`, we can join an error returned by the `defer`'d func with any other error(s), surface visibility on all errors, and avoid exiting successfully if ever an error occurs within the `defer`'d func.

This is especially helpful in CI/CD pipelines where non-successful `tfmigrate plan` execution likely indicates a problem that should gate the execution of the pipeline.

@minamijoyo Is this a technique you'd be receptive to? If so, I can give some more thoughts to acceptance testing it.