### PR TITLE
add skip_plan option to state migrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,6 +575,7 @@ The `state` migration updates the state in a single directory. It has the follow
   - `"import <address> <id>"`
   - `"replace-provider <address> <address>"`
 - `force` (optional): Apply migrations even if plan show changes
+- `skip_plan` (optional): If true, `tfmigrate` will not perform and analyze a `terraform plan`.
 
 Note that `dir` is relative path to the current working directory where `tfmigrate` command is invoked.
 

--- a/tfmigrate/state_import_action_test.go
+++ b/tfmigrate/state_import_action_test.go
@@ -40,7 +40,7 @@ resource "time_static" "baz" { triggers = {} }
 		NewStateImportAction("time_static.baz", "2006-01-02T15:04:05Z"),
 	}
 
-	m := NewStateMigrator(tf.Dir(), workspace, actions, &MigratorOption{}, false)
+	m := NewStateMigrator(tf.Dir(), workspace, actions, &MigratorOption{}, false, false)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)

--- a/tfmigrate/state_mv_action_test.go
+++ b/tfmigrate/state_mv_action_test.go
@@ -43,7 +43,7 @@ resource "null_resource" "baz" {}
 		NewStateMvAction("null_resource.bar", "null_resource.bar2"),
 	}
 
-	m := NewStateMigrator(tf.Dir(), workspace, actions, &MigratorOption{}, false)
+	m := NewStateMigrator(tf.Dir(), workspace, actions, &MigratorOption{}, false, false)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)

--- a/tfmigrate/state_replace_provider_action_test.go
+++ b/tfmigrate/state_replace_provider_action_test.go
@@ -36,7 +36,7 @@ resource "null_resource" "foo" {}
 	}
 
 	expected := "replace-provider action requires Terraform version >= 0.13.0"
-	m := NewStateMigrator(tf.Dir(), workspace, actions, &MigratorOption{}, false)
+	m := NewStateMigrator(tf.Dir(), workspace, actions, &MigratorOption{}, false, false)
 	err := m.Plan(ctx)
 	if err == nil || strings.Contains(err.Error(), expected) {
 		t.Fatalf("expected to receive '%s' error using legacy Terraform; got: %s", expected, err)
@@ -96,7 +96,7 @@ func TestAccStateReplaceProviderAction(t *testing.T) {
 		NewStateReplaceProviderAction("registry.terraform.io/-/null", "registry.terraform.io/hashicorp/null"),
 	}
 
-	m := NewStateMigrator(tf.Dir(), workspace, actions, &MigratorOption{}, false)
+	m := NewStateMigrator(tf.Dir(), workspace, actions, &MigratorOption{}, false, false)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)

--- a/tfmigrate/state_rm_action_test.go
+++ b/tfmigrate/state_rm_action_test.go
@@ -42,7 +42,7 @@ resource "null_resource" "baz" {}
 		NewStateRmAction([]string{"null_resource.qux"}),
 	}
 
-	m := NewStateMigrator(tf.Dir(), workspace, actions, &MigratorOption{}, false)
+	m := NewStateMigrator(tf.Dir(), workspace, actions, &MigratorOption{}, false, false)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)

--- a/tfmigrate/state_xmv_action_test.go
+++ b/tfmigrate/state_xmv_action_test.go
@@ -39,7 +39,7 @@ resource "null_resource" "bar2" {}
 		NewStateXmvAction("null_resource.*", "null_resource.${1}2"),
 	}
 
-	m := NewStateMigrator(tf.Dir(), workspace, actions, &MigratorOption{}, false)
+	m := NewStateMigrator(tf.Dir(), workspace, actions, &MigratorOption{}, false, false)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)


### PR DESCRIPTION
This addresses issue #151 to add a `skip_plan` option to single state migrations, similar to the `from_skip_plan` and `to_skip_plan` options supported by multi state migrations.