### PR TITLE
use multierror instead of errors.Join

### DIFF
--- a/tfmigrate/multi_state_migrator.go
+++ b/tfmigrate/multi_state_migrator.go
@@ -2,11 +2,11 @@ package tfmigrate
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"os"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/minamijoyo/tfmigrate/tfexec"
 )
 
@@ -126,7 +126,7 @@ func (m *MultiStateMigrator) plan(ctx context.Context) (fromCurrentState *tfexec
 	}
 	// switch back it to remote on exit.
 	defer func() {
-		err = errors.Join(err, fromSwitchBackToRemoteFunc())
+		err = multierror.Append(err, fromSwitchBackToRemoteFunc())
 	}()
 
 	// setup toDir.
@@ -136,7 +136,7 @@ func (m *MultiStateMigrator) plan(ctx context.Context) (fromCurrentState *tfexec
 	}
 	// switch back it to remote on exit.
 	defer func() {
-		err = errors.Join(err, toSwitchBackToRemoteFunc())
+		err = multierror.Append(err, toSwitchBackToRemoteFunc())
 	}()
 
 	// computes new states by applying state migration operations to temporary states.

--- a/tfmigrate/state_migrator.go
+++ b/tfmigrate/state_migrator.go
@@ -2,11 +2,11 @@ package tfmigrate
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"os"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/minamijoyo/tfmigrate/tfexec"
 )
 
@@ -130,7 +130,7 @@ func (m *StateMigrator) plan(ctx context.Context) (currentState *tfexec.State, e
 
 	// switch back it to remote on exit.
 	defer func() {
-		err = errors.Join(err, switchBackToRemoteFunc())
+		err = multierror.Append(err, switchBackToRemoteFunc())
 	}()
 
 	// computes a new state by applying state migration operations to a temporary state.


### PR DESCRIPTION
just a small fix to help with backwards compatibility for projects stuck on go < 1.20. This just postpones use of errors.Join in favour of multierror.Append. No functional changes.