### PR TITLE
Allow use of OpenTofu by setting TFMIGRATE_EXEC_PATH to tofu

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         opentofu:
-        - 1.6.0-alpha3
+        - 1.6.0-alpha5
     env:
       OPENTOFU_VERSION: ${{ matrix.opentofu }}
       TFMIGRATE_EXEC_PATH: tofu

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-        - 1.6.2
+        - 1.6.4
         - 1.5.7
         - 1.4.7
         - 0.12.31

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,14 +32,14 @@ jobs:
         go-version-file: '.go-version'
     - name: test
       run: make test
-  testacc:
+  testacc_terraform:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
         terraform:
-        - 1.6.0
+        - 1.6.2
         - 1.5.7
         - 1.4.7
         - 0.12.31
@@ -56,5 +56,29 @@ jobs:
         docker-compose exec -T localstack /etc/localstack/init/wait_s3_bucket_exists.sh
     - name: terraform --version
       run: docker-compose run --rm tfmigrate terraform --version
+    - name: testacc
+      run: docker-compose run --rm tfmigrate make testacc
+  testacc_opentofu:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        opentofu:
+        - 1.6.0-alpha3
+    env:
+      OPENTOFU_VERSION: ${{ matrix.opentofu }}
+      TFMIGRATE_EXEC_PATH: tofu
+    steps:
+    - uses: actions/checkout@v4
+    - name: docker build
+      run: docker-compose build
+    - name: start localstack
+      run: |
+        docker-compose up -d localstack
+        docker-compose run --rm dockerize -wait tcp://localstack:4566 -timeout 60s
+        docker-compose exec -T localstack /etc/localstack/init/wait_s3_bucket_exists.sh
+    - name: tofu --version
+      run: docker-compose run --rm tfmigrate tofu --version
     - name: testacc
       run: docker-compose run --rm tfmigrate make testacc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 ARG TERRAFORM_VERSION=latest
+ARG OPENTOFU_VERSION=latest
+
 FROM hashicorp/terraform:$TERRAFORM_VERSION AS terraform
+FROM ghcr.io/opentofu/opentofu:$OPENTOFU_VERSION AS opentofu
 
 FROM golang:1.21-alpine3.18
 RUN apk --no-cache add make git bash
 COPY --from=terraform /bin/terraform /usr/local/bin/
+COPY --from=opentofu /usr/local/bin/tofu /usr/local/bin/
 WORKDIR /work
 
 COPY go.mod go.sum ./

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ Options:
 You can customize the behavior by setting environment variables.
 
 - `TFMIGRATE_LOG`: A log level. Valid values are `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`. Default to `INFO`.
-- `TFMIGRATE_EXEC_PATH`: A string how terraform command is executed. Default to `terraform`. It's intended to inject a wrapper command such as direnv. e.g.) `direnv exec . terraform`.
+- `TFMIGRATE_EXEC_PATH`: A string how terraform command is executed. Default to `terraform`. It's intended to inject a wrapper command such as direnv. e.g.) `direnv exec . terraform`. To use OpenTofu, set this to `tofu`.
 
 Some history storage implementations may read additional cloud provider-specific environment variables. For details, refer to a configuration file section for storage block described below.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       context: .
       args:
         TERRAFORM_VERSION: ${TERRAFORM_VERSION:-latest}
+        OPENTOFU_VERSION: ${OPENTOFU_VERSION:-latest}
     volumes:
       - ".:/work"
     environment:
@@ -19,6 +20,8 @@ services:
       # it appears that localstack sometimes misses API requests when run in parallel.
       TF_CLI_ARGS_apply: "--parallelism=1"
       TERRAFORM_VERSION: ${TERRAFORM_VERSION:-latest}
+      OPENTOFU_VERSION: ${OPENTOFU_VERSION:-latest}
+      TFMIGRATE_EXEC_PATH:
     depends_on:
       - localstack
       - fake-gcs-server

--- a/scripts/testacc/generate_plugin_cache.sh
+++ b/scripts/testacc/generate_plugin_cache.sh
@@ -2,6 +2,9 @@
 
 set -eo pipefail
 
+# TFMIGRATE_EXEC_PATH can be set to tofu or terraform.
+TFMIGRATE_EXEC_PATH=${TFMIGRATE_EXEC_PATH:-terraform}
+
 # When using TF_PLUGIN_CACHE_DIR, terraform init is not concurrency safe.
 # https://github.com/hashicorp/terraform/issues/25849
 # Download the providers and generate a cache once before testing.
@@ -28,11 +31,11 @@ EOF
 # available in Terraform v0.13+, but it is hard to compare versions in bash,
 # so we use the mirror unless v0.x.
 # https://developer.hashicorp.com/terraform/cli/config/config-file#implied-local-mirror-directories
-if terraform -v | grep 'Terraform v0\.'; then
+if "$TFMIGRATE_EXEC_PATH" -v | grep 'Terraform v0\.'; then
   echo "skip creating an implied local mirror"
 else
   FS_MIRROR="/tmp/plugin-mirror"
-  terraform providers mirror "${FS_MIRROR}"
+  "$TFMIGRATE_EXEC_PATH" providers mirror "${FS_MIRROR}"
 
   cat << EOF > "$HOME/.terraformrc"
 provider_installation {
@@ -43,7 +46,7 @@ provider_installation {
 EOF
 fi
 
-terraform init -input=false -no-color
+"$TFMIGRATE_EXEC_PATH" init -input=false -no-color
 
 popd
 rm -rf "$WORK_DIR"

--- a/tfexec/terraform.go
+++ b/tfexec/terraform.go
@@ -57,8 +57,9 @@ func NewPlan(b []byte) *Plan {
 // As a result, the interface is opinionated and less flexible. For running arbitrary terraform commands
 // you can use Run(), which is a low-level generic method.
 type TerraformCLI interface {
-	// Version returns a Terraform version.
-	Version(ctx context.Context) (*version.Version, error)
+	// Version returns the Terraform execType and version number.
+	// The execType can be either terraform or opentofu.
+	Version(ctx context.Context) (string, *version.Version, error)
 
 	// Init initializes the current work directory.
 	Init(ctx context.Context, opts ...string) error

--- a/tfexec/terraform.go
+++ b/tfexec/terraform.go
@@ -152,25 +152,33 @@ type terraformCLI struct {
 	Executor
 
 	// execPath is a string which executes the terraform command.
-	// If empty, default to terraform.
+	// Default to terraform. To use OpenTofu, set this to `tofu`.
 	execPath string
 }
 
 var _ TerraformCLI = (*terraformCLI)(nil)
 
 // NewTerraformCLI returns an implementation of the TerraformCLI interface.
+// This function reads the environment variable TFMIGRATE_EXEC_PATH and sets it
+// to execPath.
 func NewTerraformCLI(e Executor) TerraformCLI {
+	execPath := os.Getenv("TFMIGRATE_EXEC_PATH")
+	if len(execPath) == 0 {
+		// The default binary path is `terraform`.
+		execPath = "terraform"
+	}
+
 	return &terraformCLI{
 		Executor: e,
+		execPath: execPath,
 	}
 }
 
 // Run is a low-level generic method for running an arbitrary terraform command.
 func (c *terraformCLI) Run(ctx context.Context, args ...string) (string, string, error) {
-	// The default binary path is `terraform`.
-	name := "terraform"
+	name := c.execPath
 	// If execPath is customized
-	if len(c.execPath) > 0 {
+	if name != "terraform" {
 		// execPath may contain spaces and environment variables, so we parse it.
 		// e.g.) "direnv exec . terraform" => ["direnv", "exec", ".", "terraform"]
 		parts, err := shellwords.Parse(c.execPath)

--- a/tfexec/terraform_apply_test.go
+++ b/tfexec/terraform_apply_test.go
@@ -67,6 +67,7 @@ func TestTerraformCLIApply(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			e := NewMockExecutor(tc.mockCommands)
 			terraformCLI := NewTerraformCLI(e)
+			terraformCLI.SetExecPath("terraform")
 			err := terraformCLI.Apply(context.Background(), tc.plan, tc.opts...)
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err: %s", err)

--- a/tfexec/terraform_destroy_test.go
+++ b/tfexec/terraform_destroy_test.go
@@ -49,6 +49,7 @@ func TestTerraformCLIDestroy(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			e := NewMockExecutor(tc.mockCommands)
 			terraformCLI := NewTerraformCLI(e)
+			terraformCLI.SetExecPath("terraform")
 			err := terraformCLI.Destroy(context.Background(), tc.opts...)
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err: %s", err)

--- a/tfexec/terraform_import_test.go
+++ b/tfexec/terraform_import_test.go
@@ -142,6 +142,7 @@ func TestTerraformCLIImport(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			e := NewMockExecutor(tc.mockCommands)
 			terraformCLI := NewTerraformCLI(e)
+			terraformCLI.SetExecPath("terraform")
 			got, err := terraformCLI.Import(context.Background(), tc.state, tc.address, tc.id, tc.opts...)
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err: %s", err)

--- a/tfexec/terraform_init_test.go
+++ b/tfexec/terraform_init_test.go
@@ -51,6 +51,7 @@ func TestTerraformCLIInit(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			e := NewMockExecutor(tc.mockCommands)
 			terraformCLI := NewTerraformCLI(e)
+			terraformCLI.SetExecPath("terraform")
 			err := terraformCLI.Init(context.Background(), tc.opts...)
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err: %s", err)

--- a/tfexec/terraform_plan_test.go
+++ b/tfexec/terraform_plan_test.go
@@ -112,6 +112,7 @@ func TestTerraformCLIPlan(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			e := NewMockExecutor(tc.mockCommands)
 			terraformCLI := NewTerraformCLI(e)
+			terraformCLI.SetExecPath("terraform")
 			got, err := terraformCLI.Plan(context.Background(), tc.state, tc.opts...)
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err: %s", err)

--- a/tfexec/terraform_providers_test.go
+++ b/tfexec/terraform_providers_test.go
@@ -58,6 +58,7 @@ func TestTerraformCLIProviders(t *testing.T) {
 			tc.mockCommands[0].args = []string{"terraform", "providers"}
 			e := NewMockExecutor(tc.mockCommands)
 			terraformCLI := NewTerraformCLI(e)
+			terraformCLI.SetExecPath("terraform")
 			got, err := terraformCLI.Providers(context.Background())
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err: %s", err)

--- a/tfexec/terraform_providers_test.go
+++ b/tfexec/terraform_providers_test.go
@@ -6,7 +6,12 @@ import (
 	"testing"
 )
 
-var providersStdout = `
+var legacyTerraformProvidersStdout = `.
+└── provider.null
+
+`
+
+var terraformProvidersStdout = `
 Providers required by configuration:
 .
 └── provider[registry.terraform.io/hashicorp/null]
@@ -17,8 +22,14 @@ Providers required by state:
 
 `
 
-var legacyProvidersStdout = `.
-└── provider.null
+var opentofuProvidersStdout = `
+Providers required by configuration:
+.
+└── provider[registry.opentofu.org/hashicorp/null]
+
+Providers required by state:
+
+    provider[registry.opentofu.org/hashicorp/null]
 
 `
 
@@ -34,11 +45,11 @@ func TestTerraformCLIProviders(t *testing.T) {
 			desc: "basic invocation",
 			mockCommands: []*mockCommand{
 				{
-					stdout:   providersStdout,
+					stdout:   terraformProvidersStdout,
 					exitCode: 0,
 				},
 			},
-			want: providersStdout,
+			want: terraformProvidersStdout,
 			ok:   true,
 		},
 		{
@@ -103,9 +114,20 @@ resource "null_resource" "bar" {}
 		t.Fatalf("failed to determine if Terraform version supports state replace-provider: %s", err)
 	}
 
-	want := providersStdout
-	if !supportsStateReplaceProvider {
-		want = legacyProvidersStdout
+	execType, _, err := terraformCLI.Version(context.Background())
+	if err != nil {
+		t.Fatalf("failed to detect execType: %s", err)
+	}
+	want := ""
+	switch execType {
+	case "terraform":
+		if !supportsStateReplaceProvider {
+			want = legacyTerraformProvidersStdout
+		} else {
+			want = terraformProvidersStdout
+		}
+	case "opentofu":
+		want = opentofuProvidersStdout
 	}
 
 	if got != want {

--- a/tfexec/terraform_state_list_test.go
+++ b/tfexec/terraform_state_list_test.go
@@ -141,6 +141,7 @@ null_resource.foo
 		t.Run(tc.desc, func(t *testing.T) {
 			e := NewMockExecutor(tc.mockCommands)
 			terraformCLI := NewTerraformCLI(e)
+			terraformCLI.SetExecPath("terraform")
 			got, err := terraformCLI.StateList(context.Background(), tc.state, tc.addresses, tc.opts...)
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err: %s", err)

--- a/tfexec/terraform_state_mv_test.go
+++ b/tfexec/terraform_state_mv_test.go
@@ -205,6 +205,7 @@ func TestTerraformCLIStateMv(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			e := NewMockExecutor(tc.mockCommands)
 			terraformCLI := NewTerraformCLI(e)
+			terraformCLI.SetExecPath("terraform")
 			gotState, gotStateOut, err := terraformCLI.StateMv(context.Background(), tc.state, tc.stateOut, tc.source, tc.destination, tc.opts...)
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err: %s", err)

--- a/tfexec/terraform_state_pull_test.go
+++ b/tfexec/terraform_state_pull_test.go
@@ -57,6 +57,7 @@ func TestTerraformCLIStatePull(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			e := NewMockExecutor(tc.mockCommands)
 			terraformCLI := NewTerraformCLI(e)
+			terraformCLI.SetExecPath("terraform")
 			got, err := terraformCLI.StatePull(context.Background(), tc.opts...)
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err: %s", err)

--- a/tfexec/terraform_state_push_test.go
+++ b/tfexec/terraform_state_push_test.go
@@ -61,6 +61,7 @@ func TestTerraformCLIStatePush(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			e := NewMockExecutor(tc.mockCommands)
 			terraformCLI := NewTerraformCLI(e)
+			terraformCLI.SetExecPath("terraform")
 			err := terraformCLI.StatePush(context.Background(), tc.state, tc.opts...)
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err: %s", err)

--- a/tfexec/terraform_state_replace_provider.go
+++ b/tfexec/terraform_state_replace_provider.go
@@ -29,7 +29,7 @@ func (c *terraformCLI) SupportsStateReplaceProvider(ctx context.Context) (bool, 
 		return false, constraints, err
 	}
 
-	v, err := c.Version(ctx)
+	_, v, err := c.Version(ctx)
 	if err != nil {
 		return false, constraints, err
 	}

--- a/tfexec/terraform_state_replace_provider_test.go
+++ b/tfexec/terraform_state_replace_provider_test.go
@@ -261,7 +261,7 @@ resource "null_resource" "bar" {}
 		t.Fatalf("failed to run terraform providers: %s", err)
 	}
 
-	wantProviders := legacyProvidersStdout
+	wantProviders := legacyTerraformProvidersStdout
 
 	if gotProviders != wantProviders {
 		t.Errorf("got: %s, want: %s", gotProviders, wantProviders)
@@ -319,7 +319,17 @@ resource "null_resource" "bar" {}
 		t.Fatalf("failed to run terraform providers: %s", err)
 	}
 
-	wantProviders := providersStdout
+	execType, _, err := terraformCLI.Version(context.Background())
+	if err != nil {
+		t.Fatalf("failed to detect execType: %s", err)
+	}
+	wantProviders := ""
+	switch execType {
+	case "terraform":
+		wantProviders = terraformProvidersStdout
+	case "opentofu":
+		wantProviders = opentofuProvidersStdout
+	}
 
 	if gotProviders != wantProviders {
 		t.Errorf("got: %s, want: %s", gotProviders, wantProviders)

--- a/tfexec/terraform_state_replace_provider_test.go
+++ b/tfexec/terraform_state_replace_provider_test.go
@@ -199,6 +199,7 @@ func TestTerraformCLIStateReplaceProvider(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			e := NewMockExecutor(tc.mockCommands)
 			terraformCLI := NewTerraformCLI(e)
+			terraformCLI.SetExecPath("terraform")
 			gotState, err := terraformCLI.StateReplaceProvider(context.Background(), tc.state, tc.source, tc.destination, tc.opts...)
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err: %s", err)

--- a/tfexec/terraform_state_rm_test.go
+++ b/tfexec/terraform_state_rm_test.go
@@ -120,6 +120,7 @@ func TestTerraformCLIStateRm(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			e := NewMockExecutor(tc.mockCommands)
 			terraformCLI := NewTerraformCLI(e)
+			terraformCLI.SetExecPath("terraform")
 			got, err := terraformCLI.StateRm(context.Background(), tc.state, tc.addresses, tc.opts...)
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err: %s", err)

--- a/tfexec/terraform_test.go
+++ b/tfexec/terraform_test.go
@@ -26,9 +26,10 @@ func TestTerraformCLIRun(t *testing.T) {
 					exitCode: 0,
 				},
 			},
-			args: []string{"version"},
-			want: "Terraform v0.12.28\n",
-			ok:   true,
+			args:     []string{"version"},
+			execPath: "terraform",
+			want:     "Terraform v0.12.28\n",
+			ok:       true,
 		},
 		{
 			desc: "failed to run terraform version",
@@ -38,9 +39,10 @@ func TestTerraformCLIRun(t *testing.T) {
 					exitCode: 1,
 				},
 			},
-			args: []string{"version"},
-			want: "",
-			ok:   false,
+			args:     []string{"version"},
+			execPath: "terraform",
+			want:     "",
+			ok:       false,
 		},
 		{
 			desc: "with execPath (no space)",
@@ -68,6 +70,20 @@ func TestTerraformCLIRun(t *testing.T) {
 			args:     []string{"version"},
 			execPath: "direnv exec . terraform",
 			want:     "Terraform v0.12.28\n",
+			ok:       true,
+		},
+		{
+			desc: "with execPath (tofu)",
+			mockCommands: []*mockCommand{
+				{
+					args:     []string{"tofu", "version"},
+					stdout:   "OpenTofu v1.6.0-alpha3\n",
+					exitCode: 0,
+				},
+			},
+			args:     []string{"version"},
+			execPath: "tofu",
+			want:     "OpenTofu v1.6.0-alpha3\n",
 			ok:       true,
 		},
 	}

--- a/tfexec/terraform_version.go
+++ b/tfexec/terraform_version.go
@@ -10,7 +10,7 @@ import (
 )
 
 // tfVersionRe is a pattern to parse outputs from terraform version.
-var tfVersionRe = regexp.MustCompile(`^Terraform v(.+)\s*\n`)
+var tfVersionRe = regexp.MustCompile(`^(Terraform|OpenTofu) v(.+)\s*\n`)
 
 // Version returns a version number of Terraform.
 func (c *terraformCLI) Version(ctx context.Context) (*version.Version, error) {
@@ -20,10 +20,10 @@ func (c *terraformCLI) Version(ctx context.Context) (*version.Version, error) {
 	}
 
 	matched := tfVersionRe.FindStringSubmatch(stdout)
-	if len(matched) != 2 {
+	if len(matched) != 3 {
 		return nil, fmt.Errorf("failed to parse terraform version: %s", stdout)
 	}
-	version, err := version.NewVersion(matched[1])
+	version, err := version.NewVersion(matched[2])
 	if err != nil {
 		return nil, err
 	}

--- a/tfexec/terraform_version_test.go
+++ b/tfexec/terraform_version_test.go
@@ -13,20 +13,35 @@ func TestTerraformCLIVersion(t *testing.T) {
 	cases := []struct {
 		desc         string
 		mockCommands []*mockCommand
+		execPath     string
 		want         string
 		ok           bool
 	}{
 		{
-			desc: "parse outputs of terraform version",
+			desc: "terraform version",
 			mockCommands: []*mockCommand{
 				{
 					args:     []string{"terraform", "version"},
-					stdout:   "Terraform v0.12.28\n",
+					stdout:   "Terraform v1.6.2\n",
 					exitCode: 0,
 				},
 			},
-			want: "0.12.28",
-			ok:   true,
+			execPath: "terraform",
+			want:     "1.6.2",
+			ok:       true,
+		},
+		{
+			desc: "tofu version",
+			mockCommands: []*mockCommand{
+				{
+					args:     []string{"tofu", "version"},
+					stdout:   "OpenTofu v1.6.0-alpha3\n",
+					exitCode: 0,
+				},
+			},
+			execPath: "tofu",
+			want:     "1.6.0-alpha3",
+			ok:       true,
 		},
 		{
 			desc: "failed to run terraform version",
@@ -36,8 +51,9 @@ func TestTerraformCLIVersion(t *testing.T) {
 					exitCode: 1,
 				},
 			},
-			want: "",
-			ok:   false,
+			execPath: "terraform",
+			want:     "",
+			ok:       false,
 		},
 		{
 			desc: "with check point warning",
@@ -52,8 +68,9 @@ is 0.12.29. You can update by downloading from https://www.terraform.io/download
 					exitCode: 0,
 				},
 			},
-			want: "0.12.28",
-			ok:   true,
+			execPath: "terraform",
+			want:     "0.12.28",
+			ok:       true,
 		},
 	}
 
@@ -61,6 +78,7 @@ is 0.12.29. You can update by downloading from https://www.terraform.io/download
 		t.Run(tc.desc, func(t *testing.T) {
 			e := NewMockExecutor(tc.mockCommands)
 			terraformCLI := NewTerraformCLI(e)
+			terraformCLI.SetExecPath(tc.execPath)
 			got, err := terraformCLI.Version(context.Background())
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err: %s", err)

--- a/tfexec/terraform_workspace_new_test.go
+++ b/tfexec/terraform_workspace_new_test.go
@@ -51,6 +51,7 @@ func TestTerraformCLIWorkspaceNew(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			e := NewMockExecutor(tc.mockCommands)
 			terraformCLI := NewTerraformCLI(e)
+			terraformCLI.SetExecPath("terraform")
 			err := terraformCLI.WorkspaceNew(context.Background(), tc.workspace, tc.opts...)
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err: %s", err)

--- a/tfexec/terraform_workspace_select_test.go
+++ b/tfexec/terraform_workspace_select_test.go
@@ -49,6 +49,7 @@ func TestTerraformCLIWorkspaceSelect(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			e := NewMockExecutor(tc.mockCommands)
 			terraformCLI := NewTerraformCLI(e)
+			terraformCLI.SetExecPath("terraform")
 			err := terraformCLI.WorkspaceSelect(context.Background(), tc.workspace)
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err: %s", err)

--- a/tfexec/terraform_workspace_show_test.go
+++ b/tfexec/terraform_workspace_show_test.go
@@ -42,6 +42,7 @@ func TestTerraformCLIWorkspaceShow(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			e := NewMockExecutor(tc.mockCommands)
 			terraformCLI := NewTerraformCLI(e)
+			terraformCLI.SetExecPath("terraform")
 			got, err := terraformCLI.WorkspaceShow(context.Background())
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err: %s", err)

--- a/tfexec/test_helper.go
+++ b/tfexec/test_helper.go
@@ -389,7 +389,7 @@ func UpdateTestAccSource(t *testing.T, tf TerraformCLI, source string) {
 
 // MatchTerraformVersion returns true if terraform version matches a given constraints.
 func MatchTerraformVersion(ctx context.Context, tf TerraformCLI, constraints string) (bool, error) {
-	v, err := tf.Version(ctx)
+	_, v, err := tf.Version(ctx)
 	if err != nil {
 		return false, fmt.Errorf("failed to get terraform version: %s", err)
 	}
@@ -403,7 +403,7 @@ func MatchTerraformVersion(ctx context.Context, tf TerraformCLI, constraints str
 
 // IsPreleaseTerraformVersion returns true if terraform version is a prelease.
 func IsPreleaseTerraformVersion(ctx context.Context, tf TerraformCLI) (bool, error) {
-	v, err := tf.Version(ctx)
+	_, v, err := tf.Version(ctx)
 	if err != nil {
 		return false, fmt.Errorf("failed to get terraform version: %s", err)
 	}

--- a/tfmigrate/config.go
+++ b/tfmigrate/config.go
@@ -23,6 +23,7 @@ type MigratorOption struct {
 	// ExecPath is a string how terraform command is executed. Default to terraform.
 	// It's intended to inject a wrapper command such as direnv.
 	// e.g.) direnv exec . terraform
+	// To use OpenTofu, set this to `tofu`.
 	ExecPath string
 
 	// PlanOut is a path to plan file to be saved.

--- a/tfmigrate/migrator.go
+++ b/tfmigrate/migrator.go
@@ -25,11 +25,11 @@ type Migrator interface {
 // current state and a switch back function.
 func setupWorkDir(ctx context.Context, tf tfexec.TerraformCLI, workspace string, isBackendTerraformCloud bool, backendConfig []string, ignoreLegacyStateInitErr bool) (*tfexec.State, func() error, error) {
 	// check if terraform command is available.
-	version, err := tf.Version(ctx)
+	execType, version, err := tf.Version(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
-	log.Printf("[INFO] [migrator@%s] terraform version: %s\n", tf.Dir(), version)
+	log.Printf("[INFO] [migrator@%s] %s version: %s\n", tf.Dir(), execType, version)
 
 	supportsStateReplaceProvider, constraints, err := tf.SupportsStateReplaceProvider(ctx)
 	if err != nil {

--- a/tfmigrate/multi_state_migrator.go
+++ b/tfmigrate/multi_state_migrator.go
@@ -97,6 +97,8 @@ func NewMultiStateMigrator(fromDir string, toDir string, fromWorkspace string, t
 	fromTf := tfexec.NewTerraformCLI(tfexec.NewExecutor(fromDir, os.Environ()))
 	toTf := tfexec.NewTerraformCLI(tfexec.NewExecutor(toDir, os.Environ()))
 	if o != nil && len(o.ExecPath) > 0 {
+		// While NewTerraformCLI reads the environment variable TFMIGRATE_EXEC_PATH
+		// at initialization, the MigratorOption takes precedence over it.
 		fromTf.SetExecPath(o.ExecPath)
 		toTf.SetExecPath(o.ExecPath)
 	}

--- a/tfmigrate/state_migrator.go
+++ b/tfmigrate/state_migrator.go
@@ -92,6 +92,8 @@ func NewStateMigrator(dir string, workspace string, actions []StateAction,
 	e := tfexec.NewExecutor(dir, os.Environ())
 	tf := tfexec.NewTerraformCLI(e)
 	if o != nil && len(o.ExecPath) > 0 {
+		// While NewTerraformCLI reads the environment variable TFMIGRATE_EXEC_PATH
+		// at initialization, the MigratorOption takes precedence over it.
 		tf.SetExecPath(o.ExecPath)
 	}
 

--- a/tfmigrate/state_replace_provider_action_test.go
+++ b/tfmigrate/state_replace_provider_action_test.go
@@ -92,8 +92,17 @@ func TestAccStateReplaceProviderAction(t *testing.T) {
 	tf := tfexec.SetupTestAccForStateReplaceProvider(t, workspace, backend+source)
 	ctx := context.Background()
 
+	registry := "registry.terraform.io"
+	tfExecType, _, err := tf.Version(ctx)
+	if err != nil {
+		t.Fatalf("failed to get tfExecType: %s", err)
+	}
+	if tfExecType == "opentofu" {
+		registry = "registry.opentofu.org"
+	}
+
 	actions := []StateAction{
-		NewStateReplaceProviderAction("registry.terraform.io/-/null", "registry.terraform.io/hashicorp/null"),
+		NewStateReplaceProviderAction(registry+"/-/null", registry+"/hashicorp/null"),
 	}
 
 	m := NewStateMigrator(tf.Dir(), workspace, actions, &MigratorOption{}, false, false)

--- a/tfmigrate/test_helper.go
+++ b/tfmigrate/test_helper.go
@@ -4,12 +4,16 @@ import "regexp"
 
 // SwitchBackToRemoteFuncError tests verify error messages, but the
 // error message for missing bucket key in the s3 backend differs
-// depending on the Terraform version.
+// depending on the Terraform version and OpenTofu version.
 // Define a helper function to hide the difference.
-const testBucketRequiredErrorLegacyTF = `Error: "bucket": required field is not set`
-const testBucketRequiredErrorTF16 = `The attribute "bucket" is required by the backend`
+const testBucketRequiredErrorLegacyTerraform = `Error: "bucket": required field is not set`
+const testBucketRequiredErrorTerraform16 = `The attribute "bucket" is required by the backend`
+const testBucketRequiredErrorOpenTofu16 = `The "bucket" attribute value must not be empty`
 
-var testBucketRequiredErrorRE = regexp.MustCompile(testBucketRequiredErrorLegacyTF + `|` + testBucketRequiredErrorTF16)
+var testBucketRequiredErrorRE = regexp.MustCompile(
+	testBucketRequiredErrorLegacyTerraform + `|` +
+		testBucketRequiredErrorTerraform16 + `|` +
+		testBucketRequiredErrorOpenTofu16)
 
 func containsBucketRequiredError(err error) bool {
 	return testBucketRequiredErrorRE.MatchString(err.Error())


### PR DESCRIPTION
Part of #162

To use OpenTofu, a community fork of Terraform, you need to set the environment variable `TFMIGRATE_EXEC_PATH` to `tofu` 

---
To support OpenTofu, I've relaxed a regular expression so that the output of the `tofu version` command can be parsed at least. Also, to use the `tofu` command for testing, read environment variables at the time of initializing the TerraformCLI instance.

This fix optimistically assumes that Terraform and OpenTofu features and version numbers are compatible, but the implementations will diverge and eventually become incorrect as time goes on. I think some abstractions, such as capability, will be needed before adding new features depending on Terraform 1.6+.

OpenTofu has yet to be released as stable, but an alpha version is available. I've added it to the test matrix.
