### PR TITLE
Pass environment variables as "env"

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,20 @@ migration "state" "test" {
 }
 ```
 
+### Environment Variables
+
+Environment variables can be accessed in migration files via the `env` variable:
+
+```hcl
+migration "state" "test" {
+  dir = "dir1"
+  workspace = env.TFMIGRATE_WORKSPACE
+  actions = [
+    "mv aws_security_group.foo aws_security_group.foo2"
+  ]
+}
+```
+
 ### migration block
 
 - The file must contain exactly one `migration` block.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A Terraform / OpenTofu state migration tool for GitOps.
          * [storage block (s3)](#storage-block-s3)
          * [storage block (gcs)](#storage-block-gcs)
    * [Migration file](#migration-file)
+      * [Environment Variables](#environment-variables-1)
       * [migration block](#migration-block)
       * [migration block (state)](#migration-block-state)
          * [state mv](#state-mv)


### PR DESCRIPTION
A small patch to allow migration scripts to access environment variables via the "env" variable, which allows some more dynamic behaviour when migrating. With this in place, it should also be trivial to add other variables and functions that make things more Terraform-like.

As part of this I added a call to `t.Setenv` in the test setup—I don't think this should cause any issues, but if there's a better way of going about it let me know.

Resolves https://github.com/minamijoyo/tfmigrate/issues/91.