### PR TITLE
Add support for Terraform v1.9

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,9 +39,9 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-        - 1.8.0
+        - 1.9.0
+        - 1.8.5
         - 1.7.5
-        - 1.6.6
         - 0.12.31
     env:
       TERRAFORM_VERSION: ${{ matrix.terraform }}


### PR DESCRIPTION
The test matrix has been changed to support Terraform v1.9, but the code has not been changed.

One noteworthy point is that Terraform v1.9 made it possible to perform state mv across resource types, but this is only allowed via the moved block and will be rejected by the validation check in the state mv command. I don't have a specific use case to propose a change upstream, but if you have a particular use case that cannot be handled with the moved block, please let me know.