### PR TITLE
fix(deps): upgrade aws-sdk-go to v1.55.5 to use aws sso shared config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	cloud.google.com/go/storage v1.36.0
-	github.com/aws/aws-sdk-go v1.43.22
+	github.com/aws/aws-sdk-go v1.55.5
 	github.com/davecgh/go-spew v1.1.1
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/aws-sdk-go-base v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/aws/aws-sdk-go v1.31.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.43.22 h1:QY9/1TZB73UDEVQ68sUVJXf/7QUiHZl7zbbLF1wpqlc=
 github.com/aws/aws-sdk-go v1.43.22/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
+github.com/aws/aws-sdk-go v1.55.5 h1:KKUZBfBoyqy5d3swXyiC7Q76ic40rYcbqH7qjh59kzU=
+github.com/aws/aws-sdk-go v1.55.5/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=


### PR DESCRIPTION
This pull request includes an update to the `go.mod` file to upgrade the version of the AWS SDK.

Dependencies update:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L7-R7): Upgraded `github.com/aws/aws-sdk-go` from version `v1.43.22` to `v1.55.5`.
* it resolves an issue with aws sso 

```sh
$ AWS_PROFILE=super-profile ../../../../../tfmigrate plan
2024/11/06 10:23:19 [INFO] Attempting to use session-derived credentials
2024/11/06 10:23:19 [INFO] Successfully derived credentials from session
2024/11/06 10:23:19 [INFO] AWS Auth provider used: "SSOProvider"
2024/11/06 10:23:20 [INFO] [runner] no unapplied migrations
```

## Background

- `tfmigrate` get an s3 client error with aws sso shared configuration (`sso-session` section) like below

```sh
$ AWS_PROFILE=super-profile ../../../../../tfmigrate plan
2024/11/06 09:45:38 [INFO] Attempting to use session-derived credentials
failed to new s3 client: Error creating AWS session: profile "super-profile" is configured to use SSO but is missing required configuration: sso_region, sso_start_url
```

```
[sso-session some-session]
sso_start_url = https://hogehoge.awsapps.com/start
sso_region = ap-northeast-1
sso_registration_scopes = sso:account:access

[profile super-profile]
sso_session = some-session
sso_account_id = 1111111111111
sso_role_name = DeveloperAccess
region = ap-northeast-1
```
