### PR TITLE
Corrected the key name used for SkipPlan in state migration from "to_skip_plan" to "skip_plan".

### DIFF
--- a/tfmigrate/state_migrator.go
+++ b/tfmigrate/state_migrator.go
@@ -29,7 +29,7 @@ type StateMigratorConfig struct {
 	// When set forces applying even if plan shows diff.
 	Force bool `hcl:"force,optional"`
 	// SkipPlan controls whether or not to run and analyze Terraform plan.
-	SkipPlan bool `hcl:"to_skip_plan,optional"`
+	SkipPlan bool `hcl:"skip_plan,optional"`
 	// Workspace is the state workspace which the migration works with.
 	Workspace string `hcl:"workspace,optional"`
 }


### PR DESCRIPTION
In [README.md](https://github.com/minamijoyo/tfmigrate/blob/5b8e18efef24688104391711650db817d71ed304/README.md?plain=1#L601), key name used for SkipPlan in state migration is "skip_plan".
But in [tfmigrate/state_migrator.go](https://github.com/minamijoyo/tfmigrate/blob/5b8e18efef24688104391711650db817d71ed304/tfmigrate/state_migrator.go#L32), key name used for SkipPlan in state migration is "to_skip_plan".

I followed README.md and got an error "Unsupported argument; An argument named ‘skip_plan’ is not expected here".
When I changed the key name to "to_skip_plan" from "skip_plan", no error occurred.

