### PR TITLE
Restore and deprecate the `to_skip_plan` in a single-state migration

### DIFF
--- a/config/migration_test.go
+++ b/config/migration_test.go
@@ -171,6 +171,52 @@ migration "state" "test" {
 			ok: true,
 		},
 		{
+			desc: "state with skip_plan",
+			source: `
+migration "state" "test" {
+	skip_plan = true
+	actions = [
+		"mv null_resource.foo null_resource.foo2",
+	]
+}
+`,
+			want: &tfmigrate.MigrationConfig{
+				Type: "state",
+				Name: "test",
+				Migrator: &tfmigrate.StateMigratorConfig{
+					Dir: "",
+					Actions: []string{
+						"mv null_resource.foo null_resource.foo2",
+					},
+					SkipPlan: true,
+				},
+			},
+			ok: true,
+		},
+		{
+			desc: "state with to_skip_plan",
+			source: `
+migration "state" "test" {
+	to_skip_plan = true
+	actions = [
+		"mv null_resource.foo null_resource.foo2",
+	]
+}
+`,
+			want: &tfmigrate.MigrationConfig{
+				Type: "state",
+				Name: "test",
+				Migrator: &tfmigrate.StateMigratorConfig{
+					Dir: "",
+					Actions: []string{
+						"mv null_resource.foo null_resource.foo2",
+					},
+					ToSkipPlan: true,
+				},
+			},
+			ok: true,
+		},
+		{
 			desc: "multi state with from_dir and to_dir",
 			source: `
 migration "multi_state" "mv_dir1_dir2" {

--- a/tfmigrate/state_migrator.go
+++ b/tfmigrate/state_migrator.go
@@ -30,6 +30,10 @@ type StateMigratorConfig struct {
 	Force bool `hcl:"force,optional"`
 	// SkipPlan controls whether or not to run and analyze Terraform plan.
 	SkipPlan bool `hcl:"skip_plan,optional"`
+	// ToSkipPlan controls whether or not to run and analyze Terraform plan.
+	// Note: This variable exists only to maintain compatibility with an old bug
+	// but is deprecated. It will be removed in a future version.
+	ToSkipPlan bool `hcl:"to_skip_plan,optional"`
 	// Workspace is the state workspace which the migration works with.
 	Workspace string `hcl:"workspace,optional"`
 }
@@ -64,7 +68,13 @@ func (c *StateMigratorConfig) NewMigrator(o *MigratorOption) (Migrator, error) {
 		c.Workspace = "default"
 	}
 
-	return NewStateMigrator(dir, c.Workspace, actions, o, c.Force, c.SkipPlan), nil
+	// This logic remains to maintain compatibility with an old bug but will be
+	// removed in a future version.
+	skipPlan := c.SkipPlan || c.ToSkipPlan
+	if c.ToSkipPlan {
+		log.Printf("[WARN] [migrator@%s] `to_skip_plan` is deprecated. Use `skip_plan` instead.", dir)
+	}
+	return NewStateMigrator(dir, c.Workspace, actions, o, c.Force, skipPlan), nil
 }
 
 // StateMigrator implements the Migrator interface.

--- a/tfmigrate/state_migrator_test.go
+++ b/tfmigrate/state_migrator_test.go
@@ -110,11 +110,20 @@ func TestStateMigratorConfigNewMigrator(t *testing.T) {
 				Dir: "dir1",
 				Actions: []string{
 					"mv null_resource.foo null_resource.foo2",
-					"mv null_resource.bar null_resource.bar2",
-					"rm time_static.baz",
-					"import time_static.qux 2006-01-02T15:04:05Z",
 				},
 				SkipPlan: true,
+			},
+			o:  nil,
+			ok: true,
+		},
+		{
+			desc: "with to_skip_plan true",
+			config: &StateMigratorConfig{
+				Dir: "dir1",
+				Actions: []string{
+					"mv null_resource.foo null_resource.foo2",
+				},
+				ToSkipPlan: true,
 			},
 			o:  nil,
 			ok: true,


### PR DESCRIPTION
This is a follow-up to #193. Renaming the `to_skip_plan` attribute in a single-state migration block to `skip_plan` was an incompatible change to the HCL file's syntax. Since it is technically possible to maintain backward compatibility, we will continue to accept the old `to_skip_plan` and log a warning. This attribute will be removed in a future version. Use `skip_plan` instead.