### PR TITLE
Fix the problem that TFMIGRATE_EXEC_PATH=terragrunt raise parse error.

### DIFF
--- a/tfexec/terraform_version.go
+++ b/tfexec/terraform_version.go
@@ -10,7 +10,7 @@ import (
 )
 
 // tfVersionRe is a pattern to parse outputs from terraform version.
-var tfVersionRe = regexp.MustCompile(`^(Terraform|OpenTofu) v(.+)\s*\n`)
+var tfVersionRe = regexp.MustCompile(`^(Terraform|OpenTofu|terragrunt)(?: version)? v(.+)\s*\n`)
 
 // Version returns the Terraform execType and version number.
 // The execType can be either terraform or opentofu.
@@ -31,6 +31,8 @@ func (c *terraformCLI) Version(ctx context.Context) (string, *version.Version, e
 		execType = "terraform"
 	case "OpenTofu":
 		execType = "opentofu"
+	case "terragrunt":
+		execType = "terragrunt"
 	default:
 		return "", nil, fmt.Errorf("unknown execType: %s", matched[1])
 	}


### PR DESCRIPTION
I encountered the problem that `TFMIGRATE_EXEC_PATH=terragrunt` raised the following parse error.
```
~/TerraformMy$ (cd envs/messi/aws-ap-northeast-1 && TFMIGRATE_EXEC_PATH=terragrunt tfmigrate plan)
2025/03/06 16:03:41 [INFO] AWS Auth provider used: "EnvProvider"
2025/03/06 16:03:42 [INFO] [runner] unapplied migration files: [20250306145900_rename_test.hcl]
2025/03/06 16:03:42 [INFO] [runner] load migration file: tfmigrate/20250306145900_rename_test.hcl
2025/03/06 16:03:42 [INFO] [migrator] start state migrator plan
failed to parse terraform version: terragrunt version v0.73.11
```

But [README.md](https://github.com/minamijoyo/tfmigrate/blob/master/README.md?plain=1#L97-L106) said that you can use terragrunt by setting `TFMIGRATE_EXEC_PATH=terragrunt`.

So I fixed it.

FYI, `terragrunt version` output is a little bit different from `terraform version`.
```
$ terragrunt version
terragrunt version v0.73.11
```
```
$ terraform version
Terraform v1.11.0
on linux_amd64

Your version of Terraform is out of date! The latest version
is 1.11.1. You can update by downloading from https://www.terraform.io/downloads.html
```
