### PR TITLE
Allow environment variables to be injected into .tfmigrate.hcl

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,21 @@ tfmigrate {
 }
 ```
 
+Environment variables can be accessed in the configuration file via the `env` variable:
+
+```hcl
+tfmigrate {
+  migration_dir = "./tfmigrate"
+  is_backend_terraform_cloud = true
+  history {
+    storage "s3" {
+      bucket = "tfmigrate-test"
+      key    = "tfmigrate/${env.VAR_NAME}/history.json"
+    }
+  }
+}
+```
+
 #### is_backend_terraform_cloud
 Whether the remote backend specified in Terraform files references a
 [terraform cloud remote backend](https://www.terraform.io/language/settings/terraform-cloud),

--- a/config/history.go
+++ b/config/history.go
@@ -1,6 +1,9 @@
 package config
 
-import "github.com/minamijoyo/tfmigrate/history"
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/minamijoyo/tfmigrate/history"
+)
 
 // HistoryBlock represents a block for migration history management in HCL.
 type HistoryBlock struct {
@@ -9,8 +12,8 @@ type HistoryBlock struct {
 }
 
 // parseHistoryBlock parses a history block and returns a *history.Config.
-func parseHistoryBlock(b HistoryBlock) (*history.Config, error) {
-	storage, err := parseStorageBlock(b.Storage)
+func parseHistoryBlock(b HistoryBlock, ctx *hcl.EvalContext) (*history.Config, error) {
+	storage, err := parseStorageBlock(b.Storage, ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/config/migration.go
+++ b/config/migration.go
@@ -2,8 +2,6 @@ package config
 
 import (
 	"fmt"
-	"os"
-	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
@@ -32,16 +30,6 @@ type MigrationBlock struct {
 	// We first decode only a block header and then decode schema depending on
 	// its type label.
 	Remain hcl.Body `hcl:",remain"`
-}
-
-// Return a map of environment variables.
-func envVarMap() cty.Value {
-	envMap := make(map[string]cty.Value)
-	for _, env := range os.Environ() {
-		pair := strings.SplitN(env, "=", 2)
-		envMap[pair[0]] = cty.StringVal(pair[1])
-	}
-	return cty.MapVal(envMap)
 }
 
 // ParseMigrationFile parses a given source of migration file and returns a *tfmigrate.MigrationConfig.

--- a/config/storage.go
+++ b/config/storage.go
@@ -27,19 +27,19 @@ type StorageBlock struct {
 }
 
 // parseStorageBlock parses a storage block and returns a storage.Config.
-func parseStorageBlock(b StorageBlock) (storage.Config, error) {
+func parseStorageBlock(b StorageBlock, ctx *hcl.EvalContext) (storage.Config, error) {
 	switch b.Type {
 	case "mock": // only for testing
-		return parseMockStorageBlock(b)
+		return parseMockStorageBlock(b, ctx)
 
 	case "local":
-		return parseLocalStorageBlock(b)
+		return parseLocalStorageBlock(b, ctx)
 
 	case "s3":
-		return parseS3StorageBlock(b)
+		return parseS3StorageBlock(b, ctx)
 
 	case "gcs":
-		return parseGCSStorageBlock(b)
+		return parseGCSStorageBlock(b, ctx)
 
 	default:
 		return nil, fmt.Errorf("unknown history storage type: %s", b.Type)
@@ -47,9 +47,9 @@ func parseStorageBlock(b StorageBlock) (storage.Config, error) {
 }
 
 // parseMockStorageBlock parses a storage block for mock and returns a storage.Config.
-func parseMockStorageBlock(b StorageBlock) (storage.Config, error) {
+func parseMockStorageBlock(b StorageBlock, ctx *hcl.EvalContext) (storage.Config, error) {
 	var config mock.Config
-	diags := gohcl.DecodeBody(b.Remain, nil, &config)
+	diags := gohcl.DecodeBody(b.Remain, ctx, &config)
 	if diags.HasErrors() {
 		return nil, diags
 	}
@@ -58,9 +58,9 @@ func parseMockStorageBlock(b StorageBlock) (storage.Config, error) {
 }
 
 // parseLocalStorageBlock parses a storage block for local and returns a storage.Config.
-func parseLocalStorageBlock(b StorageBlock) (storage.Config, error) {
+func parseLocalStorageBlock(b StorageBlock, ctx *hcl.EvalContext) (storage.Config, error) {
 	var config local.Config
-	diags := gohcl.DecodeBody(b.Remain, nil, &config)
+	diags := gohcl.DecodeBody(b.Remain, ctx, &config)
 	if diags.HasErrors() {
 		return nil, diags
 	}
@@ -69,9 +69,9 @@ func parseLocalStorageBlock(b StorageBlock) (storage.Config, error) {
 }
 
 // parseS3StorageBlock parses a storage block for s3 and returns a storage.Config.
-func parseS3StorageBlock(b StorageBlock) (storage.Config, error) {
+func parseS3StorageBlock(b StorageBlock, ctx *hcl.EvalContext) (storage.Config, error) {
 	var config s3.Config
-	diags := gohcl.DecodeBody(b.Remain, nil, &config)
+	diags := gohcl.DecodeBody(b.Remain, ctx, &config)
 	if diags.HasErrors() {
 		return nil, diags
 	}
@@ -79,9 +79,9 @@ func parseS3StorageBlock(b StorageBlock) (storage.Config, error) {
 	return &config, nil
 }
 
-func parseGCSStorageBlock(b StorageBlock) (storage.Config, error) {
+func parseGCSStorageBlock(b StorageBlock, ctx *hcl.EvalContext) (storage.Config, error) {
 	var config gcs.Config
-	diags := gohcl.DecodeBody(b.Remain, nil, &config)
+	diags := gohcl.DecodeBody(b.Remain, ctx, &config)
 	if diags.HasErrors() {
 		return nil, diags
 	}


### PR DESCRIPTION
While #171 already allows environment variables to be injected into the migration file, it would be helpful to be able to use environment variables in the configuration file as well.

This is related to the discussion in #199 and #200.