### PR TITLE
Allow setting --config via the environment variable TFMIGRATE_CONFIG

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,13 +406,14 @@ You can customize the behavior by setting environment variables.
 
 - `TFMIGRATE_LOG`: A log level. Valid values are `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`. Default to `INFO`.
 - `TFMIGRATE_EXEC_PATH`: A string how terraform command is executed. Default to `terraform`. It's intended to inject a wrapper command such as direnv. e.g.) `direnv exec . terraform`. To use OpenTofu, set this to `tofu`.
+- `TFMIGRATE_CONFIG`: A path to the tfmigrate configuration file. Default to `.tfmigrate.hcl`.
 
 Some history storage implementations may read additional cloud provider-specific environment variables. For details, refer to a configuration file section for storage block described below.
 
 ### Configuration file
 
 You can customize the behavior by setting a configuration file.
-The path of configuration file defaults to `.tfmigrate.hcl`. You can change it with command line flag `--config`.
+The path of configuration file defaults to `.tfmigrate.hcl`. You can change it with command line flag `--config` or `TFMIGRATE_CONFIG` environment variable.
 
 The syntax of configuration file is as follows:
 

--- a/command/meta.go
+++ b/command/meta.go
@@ -28,17 +28,28 @@ type Meta struct {
 	Option *tfmigrate.MigratorOption
 }
 
+// newConfig loads the configuration file.
 func newConfig(filename string) (*config.TfmigrateConfig, error) {
+	pathToLoad := filename // Start with the provided filename
+
+	// If the provided filename is the default, check the environment variable.
 	if filename == defaultConfigFile {
-		if _, err := os.Stat(defaultConfigFile); os.IsNotExist(err) {
-			// If defaultConfigFile doesn't exist,
-			// Ignore the error and just return a default config.
-			return config.NewDefaultConfig(), nil
+		envConfig := os.Getenv("TFMIGRATE_CONFIG")
+		if envConfig != "" {
+			// If TFMIGRATE_CONFIG is set, use its value.
+			pathToLoad = envConfig
+		} else {
+			// If TFMIGRATE_CONFIG is not set, check if the default file exists.
+			if _, err := os.Stat(defaultConfigFile); os.IsNotExist(err) {
+				// If defaultConfigFile doesn't exist, return a default config.
+				return config.NewDefaultConfig(), nil
+			}
+			// If defaultConfigFile exists, pathToLoad remains defaultConfigFile.
 		}
 	}
 
-	log.Printf("[DEBUG] [command] load configuration file: %s\n", filename)
-	return config.LoadConfigurationFile(filename)
+	log.Printf("[DEBUG] [command] load configuration file: %s\n", pathToLoad)
+	return config.LoadConfigurationFile(pathToLoad)
 }
 
 func newOption() *tfmigrate.MigratorOption {

--- a/command/meta_test.go
+++ b/command/meta_test.go
@@ -1,0 +1,127 @@
+package command
+
+import (
+	"os"
+	"testing"
+)
+
+func TestNewConfig(t *testing.T) {
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Chdir(origWD); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	}()
+
+	tmp := t.TempDir()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+
+	defaultPath := ".tfmigrate.hcl"
+
+	cases := []struct {
+		desc      string
+		filename  string
+		setupEnv  func()
+		setupFile func()
+		wantDir   string
+		wantErr   bool
+	}{
+		{
+			desc:     "config arg, env unset",
+			filename: "arg.hcl",
+			setupEnv: func() {},
+			setupFile: func() {
+				content := `
+tfmigrate {
+  migration_dir = "arg"
+}
+`
+				if err := os.WriteFile("arg.hcl", []byte(content), 0600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantDir: "arg",
+			wantErr: false,
+		},
+		{
+			desc:     "no arg, env set",
+			filename: defaultPath,
+			setupEnv: func() { os.Setenv("TFMIGRATE_CONFIG", "env.hcl") },
+			setupFile: func() {
+				content := `
+tfmigrate {
+  migration_dir = "env"
+}
+`
+				if err := os.WriteFile("env.hcl", []byte(content), 0600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantDir: "env",
+			wantErr: false,
+		},
+		{
+			desc:     "no arg, no env, file exists",
+			filename: defaultPath,
+			setupEnv: func() {},
+			setupFile: func() {
+				content := `
+tfmigrate {
+  migration_dir = "foo"
+}
+`
+				if err := os.WriteFile(defaultPath, []byte(content), 0600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantDir: "foo",
+			wantErr: false,
+		},
+		{
+			desc:      "no arg, no env, no file",
+			filename:  defaultPath,
+			setupEnv:  func() {},
+			setupFile: func() {},
+			wantDir:   ".", // Defined in NewDefaultConfig
+			wantErr:   false,
+		},
+		{
+			desc:      "load error",
+			filename:  "doesnotexist.hcl",
+			setupEnv:  func() {},
+			setupFile: func() {},
+			wantErr:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			// cleanup
+			os.Unsetenv("TFMIGRATE_CONFIG")
+			os.Remove(defaultPath)
+
+			tc.setupEnv()
+			tc.setupFile()
+
+			cfg, err := newConfig(tc.filename)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if cfg.MigrationDir != tc.wantDir {
+				t.Errorf("MigrationDir = %q; want %q", cfg.MigrationDir, tc.wantDir)
+			}
+		})
+	}
+}


### PR DESCRIPTION
In some use cases, you may want to reuse a configuration file. In that case, specifying it with the `--config` argument would be tedious each time. Therefore, we have made it possible to set the path to the configuration file from an environment variable `TFMIGRATE_CONFIG`.

This is related to the discussion in #199.