### PR TITLE
Use the OpenTofu installer instead of Docker image on test setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 ARG TERRAFORM_VERSION=latest
-ARG OPENTOFU_VERSION=latest
-
 FROM hashicorp/terraform:$TERRAFORM_VERSION AS terraform
-FROM ghcr.io/opentofu/opentofu:$OPENTOFU_VERSION AS opentofu
+
+FROM alpine:3.21 AS opentofu
+ARG OPENTOFU_VERSION=latest
+ADD https://get.opentofu.org/install-opentofu.sh /install-opentofu.sh
+RUN chmod +x /install-opentofu.sh
+RUN apk add gpg gpg-agent
+RUN ./install-opentofu.sh --install-method standalone --opentofu-version $OPENTOFU_VERSION --install-path /usr/local/bin --symlink-path -
 
 FROM golang:1.24-alpine3.21
 RUN apk --no-cache add make git bash


### PR DESCRIPTION
Starting with OpenTofu v1.9, official Docker images are deprecated. It is recommended to use the official installer instead. The official Docker images will be removed in v1.10.
https://opentofu.org/docs/intro/install/docker/

In line with this change, we need to fix the OpenTofu installation method on the test setup.