### PR TITLE
Add support for Terraform v1.15

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,8 +39,8 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-        - 1.14.3
-        - 1.13.5
+        - 1.15.0
+        - 1.14.9
         - 0.12.31
     env:
       TERRAFORM_VERSION: ${{ matrix.terraform }}

--- a/scripts/testacc/generate_plugin_cache.sh
+++ b/scripts/testacc/generate_plugin_cache.sh
@@ -19,8 +19,8 @@ pushd "$WORK_DIR"
 cat << EOF > main.tf
 terraform {
   required_providers {
-    null = "3.2.1"
-    time = "0.9.1"
+    null = ">= 3.2.4"
+    time = ">= 0.13.1"
   }
 }
 EOF


### PR DESCRIPTION
I added Terraform v1.15 to the test matrix and confirmed that it passes.
By the way, although this isn’t directly related to Terraform v1.15 support, there was a bug causing tests to fail due to a race condition, so I fixed that as well.