### PR TITLE
Update create-github-app-token to v3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,10 +21,10 @@ jobs:
       with:
         go-version-file: '.go-version'
     - name: Generate github app token
-      uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4  # v1.10.3
+      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
       id: app-token
       with:
-        app-id: ${{ secrets.APP_ID }}
+        client-id: ${{ secrets.APP_CLIENT_ID }}
         private-key: ${{ secrets.APP_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
         repositories: homebrew-tfmigrate


### PR DESCRIPTION
Starting from create-github-app-token v3.1.0, the app-id is deprecated, use client-id instead. Note that this is not renaming the input variable; we need to update the value.